### PR TITLE
Three fixes to get this lib compiled on linux g++ 4.7.3

### DIFF
--- a/amqpcpp.h
+++ b/amqpcpp.h
@@ -16,6 +16,7 @@
 #include <limits>
 #include <cstddef>
 #include <cstring>
+#include <stdexcept>
 
 // base C include files
 #include <stdint.h>

--- a/src/exception.h
+++ b/src/exception.h
@@ -22,12 +22,6 @@ protected:
      *  @param  what
      */
     explicit Exception(const std::string &what) : runtime_error(what) {}
-
-public:
-    /**
-     *  Destructor
-     */
-    virtual ~Exception() {}
 };
     
 /**

--- a/src/protocolexception.h
+++ b/src/protocolexception.h
@@ -23,11 +23,6 @@ public:
      *  @param  what
      */
     explicit ProtocolException(const std::string &what) : Exception(what) {}
-    
-    /**
-     *  Destructor
-     */
-    virtual ~ProtocolException() {}
 };
 
 /**


### PR DESCRIPTION
Added stdexcept include to amqpcpp.h
Removed empty virtual destructors for exception.h and protocolexception.h. They were causing compile issues because of (no) noexcept specification. They were empty implementations anyway, and the ~std::exception was already virtual, so they were not needed.
