### PR TITLE
On connection::parse char* can be const

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -74,7 +74,7 @@ public:
      *  @param  size        size of the buffer to decode
      *  @return             number of bytes that were processed
      */
-    size_t parse(char *buffer, size_t size)
+    size_t parse(const char *buffer, size_t size)
     {
         return _implementation.parse(buffer, size);
     }

--- a/include/connectionimpl.h
+++ b/include/connectionimpl.h
@@ -234,7 +234,7 @@ public:
      *  @param  size        size of the buffer to decode
      *  @return             number of bytes that were processed
      */
-    size_t parse(char *buffer, size_t size);
+    size_t parse(const char *buffer, size_t size);
 
     /**
      *  Close the connection

--- a/src/connectionimpl.cpp
+++ b/src/connectionimpl.cpp
@@ -104,7 +104,7 @@ void ConnectionImpl::remove(ChannelImpl *channel)
  *  @param  size        size of the buffer to decode
  *  @return             number of bytes that were processed
  */
-size_t ConnectionImpl::parse(char *buffer, size_t size)
+size_t ConnectionImpl::parse(const char *buffer, size_t size)
 {
     // do not parse if already in an error state
     if (_state == state_closed) return 0;


### PR DESCRIPTION
Working with your library I found that on parse() method, char\* can be const. It doesn't need to write.
