### PR TITLE
Bug fix on array serialization

### DIFF
--- a/src/array.cpp
+++ b/src/array.cpp
@@ -95,11 +95,11 @@ size_t Array::size() const
     size_t size = 4;
 
     // iterate over all elements
-    for (auto iter(_fields.begin()); iter != _fields.end(); ++iter)
+    for (auto item : _fields)
     {
         // add the size of the field type and size of element
-        size += sizeof((*iter)->typeID());
-        size += (*iter)->size();
+        size += sizeof(item->typeID());
+        size += item->size();
     }
 
     // return the result
@@ -111,12 +111,14 @@ size_t Array::size() const
  */
 void Array::fill(OutBuffer& buffer) const
 {
+    buffer.add(static_cast<uint32_t>(size()-4));
+
     // iterate over all elements
-    for (auto iter(_fields.begin()); iter != _fields.end(); ++iter)
+    for (auto item : _fields)
     {
         // encode the element type and element
-        buffer.add((*iter)->typeID());
-        (*iter)->fill(buffer);
+        buffer.add((uint8_t)item->typeID());
+        item->fill(buffer);
     }
 }
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -145,7 +145,7 @@ size_t Table::size() const
 void Table::fill(OutBuffer& buffer) const
 {
     // add size
-    buffer.add((uint32_t) size()-4);
+    buffer.add(static_cast<uint32_t>(size()-4));
 
     // loop through the fields
     for (auto iter(_fields.begin()); iter != _fields.end(); ++iter)


### PR DESCRIPTION
There was a bug on array serialization, typeIDs of members were written as `uint32_t` instead of `uint8_t`.

This closes issue #8
