### PR TITLE
Bugfix: ConnectionImpl::reportError for loops runs out of bounds

### DIFF
--- a/include/connectionimpl.h
+++ b/include/connectionimpl.h
@@ -308,11 +308,11 @@ public:
         Monitor monitor(this);
 
         // all deferred result objects in the channels should report this error too
-        for (auto &iter : _channels)
+        while (!_channels.empty())
         {
             // report the errors
-            iter.second->reportError(message, false);
-            
+            _channels.begin()->second->reportError(message, false);
+
             // leap out if no longer valid
             if (!monitor.valid()) return;
         }


### PR DESCRIPTION
ConnectionImpl::reportError calls ChannelImpl::reportError of every channel. The channel then removes itself from the connection. That caused the for loop to run out of bounds. Fixed by switching to while.