### PR TITLE
Got rid of GCC compiler warnings

### DIFF
--- a/amqpcpp.h
+++ b/amqpcpp.h
@@ -37,6 +37,7 @@
 #include <amqpcpp/outbuffer.h>
 #include <amqpcpp/watchable.h>
 #include <amqpcpp/monitor.h>
+#include <amqpcpp/unused.h>
 
 // amqp types
 #include <amqpcpp/field.h>

--- a/include/bytebuffer.h
+++ b/include/bytebuffer.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <include/unused.h>
+
 /**
  *  Open namespace
  */
@@ -76,6 +78,7 @@ public:
      */
     virtual const char *data(size_t pos, size_t size) const override
     {
+        unused(size);
         return _data + pos;
     }
     

--- a/include/channel.h
+++ b/include/channel.h
@@ -520,7 +520,7 @@ public:
      *  Get the channel we're working on
      *  @return uint16_t
      */
-    const uint16_t id() const
+    uint16_t id() const
     {
         return _implementation->id();
     }

--- a/include/channelimpl.h
+++ b/include/channelimpl.h
@@ -506,7 +506,7 @@ public:
      *  Get the channel we're working on
      *  @return uint16_t
      */
-    const uint16_t id() const
+    uint16_t id() const
     {
         return _id;
     }

--- a/include/connectionhandler.h
+++ b/include/connectionhandler.h
@@ -48,7 +48,9 @@ public:
      *  @param  connection      The connection that entered the error state
      *  @param  message         Error message
      */
-    virtual void onError(Connection *connection, const char *message) {}
+    virtual void onError(Connection *connection, const char *message) {
+        unused(connection, message);
+    }
 
     /**
      *  Method that is called when the login attempt succeeded. After this method
@@ -64,7 +66,9 @@ public:
      *
      *  @param  connection      The connection that can now be used
      */
-    virtual void onConnected(Connection *connection) {}
+    virtual void onConnected(Connection *connection) {
+        unused(connection);
+    }
 
     /**
      *  Method that is called when the connection was closed.
@@ -74,7 +78,9 @@ public:
      *
      *  @param  connection      The connection that was closed and that is now unusable
      */
-    virtual void onClosed(Connection *connection) {}
+    virtual void onClosed(Connection *connection) {
+        unused(connection);
+    }
 
 };
 

--- a/include/deferred.h
+++ b/include/deferred.h
@@ -85,6 +85,7 @@ protected:
      */
     virtual const std::shared_ptr<Deferred> &reportSuccess(const std::string &name, uint32_t messagecount, uint32_t consumercount) const
     {
+        unused(name, messagecount, consumercount);
         // this is the same as a regular success message
         return reportSuccess();
     }
@@ -96,6 +97,7 @@ protected:
      */
     virtual const std::shared_ptr<Deferred> &reportSuccess(uint32_t messagecount) const
     {
+        unused(messagecount);
         // this is the same as a regular success message
         return reportSuccess();
     }
@@ -107,6 +109,7 @@ protected:
      */
     virtual const std::shared_ptr<Deferred> &reportSuccess(const std::string &name) const
     {
+        unused(name);
         // this is the same as a regular success message
         return reportSuccess();
     }

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -224,8 +224,8 @@ public:
     const std::string &expiration     () const { return _expiration;        }
     const std::string &replyTo        () const { return _replyTo;           }
     const std::string &correlationID  () const { return _correlationID;     }
-    const uint8_t      priority       () const { return _priority;          }
-    const uint8_t      deliveryMode   () const { return _deliveryMode;      }
+    uint8_t           priority        () const { return _priority;          }
+    uint8_t           deliveryMode    () const { return _deliveryMode;      }
     const Table       &headers        () const { return _headers;           }
     const std::string &contentEncoding() const { return _contentEncoding;   }
     const std::string &contentType    () const { return _contentType;       }
@@ -233,7 +233,7 @@ public:
     const std::string &appID          () const { return _appID;             }
     const std::string &userID         () const { return _userID;            }
     const std::string &typeName       () const { return _typeName;          }
-    const uint64_t     timestamp      () const { return _timestamp;         }
+    uint64_t          timestamp       () const { return _timestamp;         }
     const std::string &messageID      () const { return _messageID;         }
     
     /**

--- a/include/unused.h
+++ b/include/unused.h
@@ -1,0 +1,4 @@
+#pragma once
+
+template<class... T> void unused(T&&...)
+{ }

--- a/src/basiccancelframe.h
+++ b/src/basiccancelframe.h
@@ -102,7 +102,7 @@ public:
      *  Return whether to wait for a response
      *  @return  boolean
      */
-    const bool noWait() const
+    bool noWait() const
     {
         return _noWait.get(0);
     }

--- a/src/basicreturnframe.h
+++ b/src/basicreturnframe.h
@@ -155,6 +155,7 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
+        unused(connection);
         // we no longer support returned messages
         return false;
     }

--- a/src/extframe.h
+++ b/src/extframe.h
@@ -139,6 +139,7 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
+        unused(connection);
         // this is an exception
         throw ProtocolException("unimplemented frame type " + std::to_string(type()));
         

--- a/src/frame.h
+++ b/src/frame.h
@@ -94,6 +94,7 @@ public:
      */
     virtual bool process(ConnectionImpl *connection)
     {
+        unused(connection);
         // this is an exception
         throw ProtocolException("unimplemented frame");
 

--- a/src/methodframe.h
+++ b/src/methodframe.h
@@ -85,6 +85,7 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
+        unused(connection);
         // this is an exception
         throw ProtocolException("unimplemented frame type " + std::to_string(type()) + " class " + std::to_string(classID()) + " method " + std::to_string(methodID()));
     }


### PR DESCRIPTION
There were a number of compiler warnings due to unused parameters or ignored type qualifiers on returns.
I introduced a file unused.h  and the unused method for unused parameters and removed superflous const for return types.