### PR TITLE
AMQP::Envelope copy constructor missing base class constructor call

### DIFF
--- a/include/envelope.h
+++ b/include/envelope.h
@@ -68,6 +68,7 @@ public:
      *  @param  envelope    the envelope to copy
      */
     Envelope(const Envelope &envelope) :
+        MetaData(envelope),
         _str(envelope._body, envelope._bodySize),
         _body(_str.data()),
         _bodySize(_str.size())


### PR DESCRIPTION
Fixes #43 and #42