### PR TITLE
The server heartbeat is stored in Connection

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -154,6 +154,15 @@ public:
     }
 
     /**
+    *  Retrieve the heartbeat delay used by this connection
+    *  @return uint16_t
+    */
+    uint16_t heartbeat() const
+    {
+        return _implementation.heartbeat();
+    }
+
+    /**
      *  Some classes have access to private properties
      */
     friend class ChannelImpl;

--- a/include/connectionimpl.h
+++ b/include/connectionimpl.h
@@ -94,6 +94,12 @@ protected:
     std::queue<OutBuffer> _queue;
 
     /**
+    *  Heartbeat delay
+    *  @var uint16_t
+    */
+    uint16_t _heartbeat = 0;
+
+    /**
      *  Helper method to send the close frame
      *  Return value tells if the connection is still valid
      *  @return bool
@@ -340,6 +346,23 @@ public:
     std::size_t channels() const
     {
         return _channels.size();
+    }
+
+    /**
+     *  Heartbeat delay
+     *  @return uint16_t
+    */
+    uint16_t heartbeat() const
+    {
+        return _heartbeat;
+    }
+
+    /**
+     *  Set the heartbeat delay
+    */
+    void setHeartbeat(uint16_t heartbeat)
+    {
+        _heartbeat = heartbeat;
     }
 
     /**

--- a/src/connectiontuneframe.h
+++ b/src/connectiontuneframe.h
@@ -137,6 +137,9 @@ public:
         // theoretically it is possible that the connection object gets destructed between sending the messages
         Monitor monitor(connection);
         
+        // store the heartbeat the server wants 
+        connection->setHeartbeat(heartbeat());
+
         // send it back
         connection->send(ConnectionTuneOKFrame(channelMax(), frameMax(), heartbeat()));
         


### PR DESCRIPTION
Under some circumstances it can happen that our AMQP client does not receive any more messages, including heartbeats, without being able to detect an AMQP- or network error. To fix this our client expects heartbeats and resets the connection after x heartbeats were missed. To know when to expect a heartbeat I added the possibility to retrieve the servers heartbeat duration by storing it in the Connection object.