### PR TITLE
Fix compiling on OS X Yosemite

### DIFF
--- a/src/pipe.h
+++ b/src/pipe.h
@@ -42,8 +42,16 @@ public:
     Pipe()
     {
         // construct the pipe
+#ifdef _GNU_SOURCE
         if (pipe2(_fds, O_CLOEXEC) == 0) return;
-        
+#else
+        if (
+            pipe(_fds) == 0 &&
+            fcntl(_fds[0], F_SETFD, FD_CLOEXEC) == 0 &&
+            fcntl(_fds[1], F_SETFD, FD_CLOEXEC) == 0
+        ) return;
+#endif
+
         // something went wrong
         throw std::runtime_error(strerror(errno));
     }

--- a/src/tcpbuffer.h
+++ b/src/tcpbuffer.h
@@ -17,6 +17,7 @@
  *  Dependencies
  */
 #include <sys/ioctl.h>
+#include <sys/uio.h>
  
 /**
  *  Set up namespace


### PR DESCRIPTION
Before this
```
...
./pipe.h:45:13: error: use of undeclared identifier 'pipe2'
        if (pipe2(_fds, O_CLOEXEC) == 0) return;
            ^
In file included from tcpconnection.cpp:14:
In file included from ./tcpresolver.h:22:
In file included from ./tcpconnected.h:19:
./tcpbuffer.h:359:27: error: use of undeclared identifier 'writev'; did you mean 'write'?
            auto result = writev(socket, (const struct iovec *)&buffer, index);
                          ^~~~~~
                          write
/usr/include/unistd.h:490:10: note: 'write' declared here
ssize_t  write(int, const void *, size_t) __DARWIN_ALIAS_C(write);
         ^
2 warnings and 2 errors generated.
make[1]: *** [tcpconnection.o] Error 1
make: *** [all] Error 2
```

**NB**: I haven't tested it properly. I tried running tests but couldn't because of the closed source library.