### PR TITLE
fix `std:max` type mismatch

### DIFF
--- a/src/tcpbuffer.h
+++ b/src/tcpbuffer.h
@@ -403,7 +403,7 @@ public:
         if (result > 0) _size += result;
         
         // if buffer is not full
-        if (result < available) buffer.resize(std::max(0L, result));
+        if (result < available) buffer.resize(std::max(0L, (long int)result));
         
         // done
         return result;


### PR DESCRIPTION
env:
```
OS: Centos6.5 Linux 2.6.32-431.el6.i686
gcc: 4.8.2
```
make error:
```
g++ -Wall -c -I. -std=c++11 -g -fpic -o tcpconnection.o tcpconnection.cpp
In file included from tcpconnected.h:19:0,
                 from tcpresolver.h:22,
                 from tcpconnection.cpp:14:
tcpbuffer.h: In member function ‘ssize_t AMQP::TcpBuffer::receivefrom(int)’:
tcpbuffer.h:406:66: error: no matching function for call to ‘max(long int, int&)’
         if (result < available) buffer.resize(std::max(0L, result));
                                                                  ^
tcpbuffer.h:406:66: note: candidates are:
In file included from /usr/local/include/c++/4.8.2/bits/char_traits.h:39:0,
                 from /usr/local/include/c++/4.8.2/string:40,
                 from includes.h:14,
                 from tcpconnection.cpp:13:
/usr/local/include/c++/4.8.2/bits/stl_algobase.h:216:5: note: template<class _Tp> const _Tp& std::max(const _Tp&, const _Tp&)
     max(const _Tp& __a, const _Tp& __b)
     ^
/usr/local/include/c++/4.8.2/bits/stl_algobase.h:216:5: note:   template argument deduction/substitution failed:
In file included from tcpconnected.h:19:0,
                 from tcpresolver.h:22,
                 from tcpconnection.cpp:14:
tcpbuffer.h:406:66: note:   deduced conflicting types for parameter ‘const _Tp’ (‘long int’ and ‘int’)
         if (result < available) buffer.resize(std::max(0L, result));
                                                                  ^
...
```