### PR TITLE
Buildfix: tcpconnection.cpp added to build sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,4 +89,5 @@ transactionrollbackokframe.h
 transactionselectframe.h
 transactionselectokframe.h
 watchable.cpp
+tcpconnection.cpp
 )


### PR DESCRIPTION
Link fails when your TCPConnection realisation is used (through LibEventHandler for example). It needs tcpconnection.cpp to be linked too, but it is missing in the library.