### PR TITLE
Some portability fixes for Solaris-like systems

### DIFF
--- a/include/decimalfield.h
+++ b/include/decimalfield.h
@@ -108,7 +108,7 @@ public:
     virtual void output(std::ostream &stream) const override
     {
         // output floating point value
-        stream << "decimal(" << _number / pow(10, _places) << ")";
+        stream << "decimal(" << _number / pow(10.0f, _places) << ")";
     }
 
     /**
@@ -138,7 +138,7 @@ public:
      */
     virtual operator double() const override
     {
-        return _number / pow(10, _places);
+        return _number / pow(10.0f, _places);
     }
 
     /**
@@ -149,7 +149,7 @@ public:
      */
     virtual operator float() const override
     {
-        return static_cast<float>(_number / pow(10, _places));
+        return static_cast<float>(_number / pow(10.0f, _places));
     }
 
     /**

--- a/src/tcpoutbuffer.h
+++ b/src/tcpoutbuffer.h
@@ -20,6 +20,13 @@
 #include <sys/uio.h>
  
 /**
+ *  FIONREAD on Solaris is defined elsewhere
+ */
+#ifdef __sun
+#include <sys/filio.h>
+#endif
+
+/**
  *  Set up namespace
  */
 namespace AMQP {


### PR DESCRIPTION
Hi, two commits for Solaris portability.

1. `FIONREAD` is defined in `sys/filio.h`
2. the standard C++ library is missing a template overload for `pow`

The fix for 2 is a bit ugly, though.