### PR TITLE
Program crashes when receiving a message due to memory corruption

### DIFF
--- a/include/stack_ptr.h
+++ b/include/stack_ptr.h
@@ -29,7 +29,8 @@ private:
      *  Storage for the object
      *  @var    std::aligned_storage<sizeof(T), alignof(T)>
      */
-    std::aligned_storage<sizeof(T), alignof(T)> _data;
+    typedef typename std::aligned_storage<sizeof(T), alignof(T)>::type Type;
+    Type _data;
 
     /**
      *  Is the pointer initialized?
@@ -87,6 +88,7 @@ public:
 
         // initialize new object
         new (&_data) T(std::forward<Arguments>(parameters)...);
+        _initialized = true;
     }
 
     /**


### PR DESCRIPTION
crashes due to the wrong way using aligned_storage.

Steps to reproduce:
1. Start a consumer
  channel.consume(queue, tag).onMessage(msgCallback)
2. Send a message to the consumer
3. The program crashes

Environment:
Windows 7 / VS2010

The reason:
The Windows prompted to memory corruption, I found some strange phenomenon
about stack_ptr<Message>, such as:
  1.sizeof(stack_ptr<Message>) is equal to 2
  2.stack_ptr._initialized becomes true after construct() called (actually,
    it never has been assigned true, please see [1])

Finally I found that the root cause was stack_ptr._data, we directly used
aligned_storage rather than aligned_storage::type[2] as the type of _data.
so the _data was just an empty struct, and subsequent operations were
performed in illegal memory. It eventually led to the crash.

This patch we fixed the bug and add "_initialized = true" at the end of the
method stack_ptr::construct().

[1] https://github.com/CopernicaMarketingSoftware/AMQP-CPP/blob/master/include/stack_ptr.h#L83
[2] http://www.cplusplus.com/reference/type_traits/aligned_storage/