### PR TITLE
Correct the returning type of Connection::waiting()

### DIFF
--- a/include/connection.h
+++ b/include/connection.h
@@ -190,7 +190,7 @@ public:
      *  meantime you can already send more instructions over it)
      *  @return bool
      */
-    std::size_t waiting() const
+    bool waiting() const
     {
         return _implementation.waiting();
     }


### PR DESCRIPTION
The returning type of Connection::waiting() should be bool,
but currently it's size_t type.