### PR TITLE
Implement copy constructor for class Monitor

### DIFF
--- a/include/monitor.h
+++ b/include/monitor.h
@@ -58,6 +58,16 @@ public:
     }
 
     /**
+     *  Copy constructor
+     *  @param  monitor
+     */
+    Monitor(const Monitor &monitor) : _watchable(monitor._watchable)
+    {
+        // register with the watchable
+        _watchable->add(this);
+    }
+
+    /**
      *  Destructor
      */
     virtual ~Monitor()


### PR DESCRIPTION
To support the instance copy of Monitor like the following:
```
    AMQP::Monitor monitor(consumer);
    consumer->bindExchange(exchange, AMQP::direct).onSuccess([&, monitor](){
        // do something when the consumer is ready!
        if(monitor.valid())
            consumer->doSomething();
    });
```