### PR TITLE
libuv drop in implementation for TcpHandler

### DIFF
--- a/include/libuv.h
+++ b/include/libuv.h
@@ -63,7 +63,7 @@ private:
 
             // tell the connection that its filedescriptor is active
             int fd = -1;
-            uv_fileno(static_cast<uv_handle_t*>(handle), &fd);
+            uv_fileno(reinterpret_cast<uv_handle_t*>(handle), &fd);
             connection->process(fd, uv_to_amqp_events(events));
         }
 
@@ -107,9 +107,9 @@ private:
             uv_poll_stop(_poll);
 
             // close the handle
-            uv_close(static_cast<uv_handle_t*>(_poll), [](uv_handle_t* handle) {
+            uv_close(reinterpret_cast<uv_handle_t*>(_poll), [](uv_handle_t* handle) {
                 // delete memory once closed
-                delete static_cast<uv_poll_t*>(handle);
+                delete reinterpret_cast<uv_poll_t*>(handle);
             });
         }
 

--- a/include/libuv.h
+++ b/include/libuv.h
@@ -1,0 +1,220 @@
+/**
+ *  LibUV.h
+ *
+ *  Implementation for the AMQP::TcpHandler that is optimized for libuv. You can
+ *  use this class instead of a AMQP::TcpHandler class, just pass the event loop
+ *  to the constructor and you're all set.
+ *
+ *  Based heavily on the libev.h implementation by Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
+ *
+ *  @author David Nikdel <david@nikdel.com>
+ *  @copyright 2015 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Dependencies
+ */
+#include <uv.h>
+
+/**
+ *  Set up namespace
+ */
+namespace AMQP {
+
+/**
+ *  Class definition
+ */
+class LibUvHandler : public TcpHandler
+{
+private:
+    /**
+     *  Helper class that wraps a libev I/O watcher
+     */
+    class Watcher
+    {
+    private:
+        /**
+         *  The event loop to which it is attached
+         *  @var struct uv_loop_t
+         */
+        struct uv_loop_t *_loop;
+
+        /**
+         *  The actual watcher structure
+         *  @var struct uv_poll_t
+         */
+        struct uv_poll_t *_poll;
+
+        /**
+         *  Callback method that is called by libuv when a filedescriptor becomes active
+         *  @param  handle     Internal poll handle
+         *  @param  status     LibUV error code UV_*
+         *  @param  events     Events triggered
+         */
+        static void callback(struct uv_poll_t *handle, int status, int events)
+        {
+            // retrieve the connection
+            TcpConnection *connection = static_cast<TcpConnection*>(handle->data);
+
+            // tell the connection that its filedescriptor is active
+            int fd = -1;
+            uv_fileno(static_cast<uv_handle_t*>(handle), &fd);
+            connection->process(fd, uv_to_amqp_events(events));
+        }
+
+    public:
+        /**
+         *  Constructor
+         *  @param  loop            The current event loop
+         *  @param  connection      The connection being watched
+         *  @param  fd              The filedescriptor being watched
+         *  @param  events          The events that should be monitored
+         */
+        Watcher(struct uv_loop_t *loop, TcpConnection *connection, int fd, int events) : _loop(loop)
+        {
+            // create a new poll
+            _poll = new uv_poll_t();
+
+            // initialize the libev structure
+            uv_poll_init(_loop, _poll, fd);
+
+            // store the connection in the data "void*"
+            _poll->data = connection;
+
+            // start the watcher
+            uv_poll_start(_poll, amqp_to_uv_events(events), callback);
+        }
+
+        /**
+         *  Watchers cannot be copied or moved
+         *
+         *  @param  that    The object to not move or copy
+         */
+        Watcher(Watcher &&that) = delete;
+        Watcher(const Watcher &that) = delete;
+
+        /**
+         *  Destructor
+         */
+        virtual ~Watcher()
+        {
+            // stop the watcher
+            uv_poll_stop(_poll);
+
+            // close the handle
+            uv_close(static_cast<uv_handle_t*>(_poll), [](uv_handle_t* handle) {
+                // delete memory once closed
+                delete static_cast<uv_poll_t*>(handle);
+            });
+        }
+
+        /**
+         *  Change the events for which the filedescriptor is monitored
+         *  @param  events
+         */
+        void events(int events)
+        {
+            // stop the watcher if it was active
+            uv_poll_stop(_poll);
+
+            // and restart it
+            uv_poll_start(_poll, amqp_to_uv_events(events), callback);
+        }
+
+    private:
+
+        /**
+         *  Convert event flags from UV format to AMQP format
+         */
+        static int uv_to_amqp_events(int events)
+        {
+            int amqp_events = 0;
+            if (events & UV_READABLE)
+                amqp_events |= AMQP::readable;
+            if (events & UV_WRITABLE)
+                amqp_events |= AMQP::writable;
+            return amqp_events;
+        }
+
+        /**
+         *  Convert event flags from AMQP format to UV format
+         */
+        static int amqp_to_uv_events(int events)
+        {
+            int uv_events = 0;
+            if (events & AMQP::readable)
+                uv_events |= UV_READABLE;
+            if (events & AMQP::writable)
+                uv_events |= UV_WRITABLE;
+            return uv_events;
+        }
+    };
+
+
+    /**
+     *  The event loop
+     *  @var struct uv_loop_t*
+     */
+    struct uv_loop_t *_loop;
+
+    /**
+     *  All I/O watchers that are active, indexed by their filedescriptor
+     *  @var std::map<int,Watcher>
+     */
+    std::map<int,std::unique_ptr<Watcher>> _watchers;
+
+
+    /**
+     *  Method that is called by AMQP-CPP to register a filedescriptor for readability or writability
+     *  @param  connection  The TCP connection object that is reporting
+     *  @param  fd          The filedescriptor to be monitored
+     *  @param  flags       Should the object be monitored for readability or writability?
+     */
+    virtual void monitor(TcpConnection *connection, int fd, int flags) override
+    {
+        // do we already have this filedescriptor
+        auto iter = _watchers.find(fd);
+
+        // was it found?
+        if (iter == _watchers.end())
+        {
+            // we did not yet have this watcher - but that is ok if no filedescriptor was registered
+            if (flags == 0) return;
+
+            // construct a new watcher, and put it in the map
+            _watchers[fd] = std::unique_ptr<Watcher>(new Watcher(_loop, connection, fd, flags));
+        }
+        else if (flags == 0)
+        {
+            // the watcher does already exist, but we no longer have to watch this watcher
+            _watchers.erase(iter);
+        }
+        else
+        {
+            // change the events
+            iter->second->events(flags);
+        }
+    }
+
+public:
+    /**
+     *  Constructor
+     *  @param  loop    The event loop to wrap
+     */
+    LibUvHandler(struct uv_loop_t *loop) : _loop(loop) {}
+
+    /**
+     *  Destructor
+     */
+    virtual ~LibUvHandler() = default;
+};
+
+/**
+ *  End of namespace
+ */
+}

--- a/include/libuv.h
+++ b/include/libuv.h
@@ -64,7 +64,7 @@ private:
             // tell the connection that its filedescriptor is active
             int fd = -1;
             uv_fileno(reinterpret_cast<uv_handle_t*>(handle), &fd);
-            connection->process(fd, uv_to_amqp_events(events));
+            connection->process(fd, uv_to_amqp_events(status, events));
         }
 
     public:
@@ -119,10 +119,7 @@ private:
          */
         void events(int events)
         {
-            // stop the watcher if it was active
-            uv_poll_stop(_poll);
-
-            // and restart it
+            // update the events being watched for
             uv_poll_start(_poll, amqp_to_uv_events(events), callback);
         }
 
@@ -131,13 +128,15 @@ private:
         /**
          *  Convert event flags from UV format to AMQP format
          */
-        static int uv_to_amqp_events(int events)
+        static int uv_to_amqp_events(int status, int events)
         {
             int amqp_events = 0;
             if (events & UV_READABLE)
                 amqp_events |= AMQP::readable;
             if (events & UV_WRITABLE)
                 amqp_events |= AMQP::writable;
+            if (status != 0)
+                amqp_events |= AMQP::readable;
             return amqp_events;
         }
 

--- a/include/libuv.h
+++ b/include/libuv.h
@@ -40,15 +40,15 @@ private:
     private:
         /**
          *  The event loop to which it is attached
-         *  @var struct uv_loop_t
+         *  @var uv_loop_t
          */
-        struct uv_loop_t *_loop;
+        uv_loop_t *_loop;
 
         /**
          *  The actual watcher structure
-         *  @var struct uv_poll_t
+         *  @var uv_poll_t
          */
-        struct uv_poll_t *_poll;
+        uv_poll_t *_poll;
 
         /**
          *  Callback method that is called by libuv when a filedescriptor becomes active
@@ -56,7 +56,7 @@ private:
          *  @param  status     LibUV error code UV_*
          *  @param  events     Events triggered
          */
-        static void callback(struct uv_poll_t *handle, int status, int events)
+        static void callback(uv_poll_t *handle, int status, int events)
         {
             // retrieve the connection
             TcpConnection *connection = static_cast<TcpConnection*>(handle->data);
@@ -75,7 +75,7 @@ private:
          *  @param  fd              The filedescriptor being watched
          *  @param  events          The events that should be monitored
          */
-        Watcher(struct uv_loop_t *loop, TcpConnection *connection, int fd, int events) : _loop(loop)
+        Watcher(uv_loop_t *loop, TcpConnection *connection, int fd, int events) : _loop(loop)
         {
             // create a new poll
             _poll = new uv_poll_t();
@@ -157,9 +157,9 @@ private:
 
     /**
      *  The event loop
-     *  @var struct uv_loop_t*
+     *  @var uv_loop_t*
      */
-    struct uv_loop_t *_loop;
+    uv_loop_t *_loop;
 
     /**
      *  All I/O watchers that are active, indexed by their filedescriptor
@@ -205,7 +205,7 @@ public:
      *  Constructor
      *  @param  loop    The event loop to wrap
      */
-    LibUvHandler(struct uv_loop_t *loop) : _loop(loop) {}
+    LibUvHandler(uv_loop_t *loop) : _loop(loop) {}
 
     /**
      *  Destructor

--- a/include/libuv.h
+++ b/include/libuv.h
@@ -130,13 +130,16 @@ private:
          */
         static int uv_to_amqp_events(int status, int events)
         {
+            // if the socket is closed report both so we pick up the error
+            if (status != 0)
+                return AMQP::readable | AMQP::writable;
+
+            // map read or write
             int amqp_events = 0;
             if (events & UV_READABLE)
                 amqp_events |= AMQP::readable;
             if (events & UV_WRITABLE)
                 amqp_events |= AMQP::writable;
-            if (status != 0)
-                amqp_events |= AMQP::readable;
             return amqp_events;
         }
 


### PR DESCRIPTION
Got this working in a project I'm working on figured I'd pay it forward.

Small notes: 
- I had to ifdef out the cast to Array in Array and cast to Table in Table (both have a note about them not being needed by the compiler). Clang actively warns on them and I compile with warnings as errors so that was mildly annoying (would like to use stock). What's the rationale for these?
- Including the external dependency (#include <uv.h>) in this file is actually something I had to remove locally because I don't include it from the system path. I've included it here for consistency with libev.h and libevent.h but I'd like to suggest they (all 3) be removed from the .h for flexibility. if someone is using libX.h and hasn't already included that it will fail to compile in an obvious way.