### PR TITLE
Fixed warnings: self-casts, const qual

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -218,16 +218,6 @@ public:
         // postfix
         stream << ")";
     }
-
-    /**
-     *  Cast to array (compiler will probably never call this method)
-     *  @return Array
-     */
-    virtual operator const Array& () const override
-    {
-        // this already is an array, so no cast is necessary
-        return *this;
-    }
 };
 
 /**

--- a/include/table.h
+++ b/include/table.h
@@ -242,16 +242,6 @@ public:
         // postfix
         stream << ")";
     }
-
-    /**
-     *  Cast to table (compiler will probably never call this method)
-     *  @return Table
-     */
-    virtual operator const Table& () const override
-    {
-        // this already is an array, so no cast is necessary
-        return *this;
-    }
 };
 
 /**

--- a/src/basiccancelframe.h
+++ b/src/basiccancelframe.h
@@ -102,7 +102,7 @@ public:
      *  Return whether to wait for a response
      *  @return  boolean
      */
-    const bool noWait() const
+    bool noWait() const
     {
         return _noWait.get(0);
     }


### PR DESCRIPTION
These patches fixed some annoying warnings in header files.
Could you please check them with your tests and merge it?