### PR TITLE
table field value type extension

### DIFF
--- a/src/field.cpp
+++ b/src/field.cpp
@@ -41,6 +41,7 @@ Field *Field::decode(ReceivedFrame &frame)
         case 'A':   return new Array(frame);
         case 'T':   return new Timestamp(frame);
         case 'F':   return new Table(frame);
+		case 'x':	return new LongString(frame); // for Qpid/Rabbit
         default:    return nullptr;
     }
 }


### PR DESCRIPTION
table's field value types extend 'x' for Qpid/Rabbit
the library rabbitmq-c has add "AMQP_FIELD_KIND_BYTES"('x') 