### PR TITLE
fix linked list bug when you add more than one element to the list

### DIFF
--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -134,7 +134,7 @@ Deferred &ChannelImpl::push(const std::shared_ptr<Deferred> &deferred)
     if (!_oldestCallback) _oldestCallback = deferred;
 
     // do we already have a newest?
-    if (_newestCallback) _newestCallback->add(deferred);
+    if (_newestCallback) deferred->add(_newestCallback);
 
     // store newest callback
     _newestCallback = deferred;


### PR DESCRIPTION
I don't think more than one is ever added so that may be why this bug went unnoticed.  But if you ever added more than one element you would loose the old head.