### PR TITLE
Add strand to boost handler

### DIFF
--- a/include/libboostasio.h
+++ b/include/libboostasio.h
@@ -120,6 +120,7 @@ private:
         /**
          *  Handler method that is called by boost's io_service when the socket pumps a read event.
          *  @param  ec          The status of the callback.
+         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
@@ -164,6 +165,7 @@ private:
         /**
          *  Handler method that is called by boost's io_service when the socket pumps a write event.
          *  @param  ec          The status of the callback.
+         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
@@ -210,6 +212,7 @@ private:
          *  Constructor- initialises the watcher and assigns the filedescriptor to 
          *  a boost socket for monitoring.
          *  @param  io_service      The boost io_service
+         *  @param  strand          A weak pointer to a io_service::strand instance.
          *  @param  fd              The filedescriptor being watched
          */
         Watcher(boost::asio::io_service &io_service,
@@ -378,7 +381,8 @@ private:
     public:
         /**
          *  Constructor
-         *  @param  loop            The current event loop
+         *  @param  io_service The boost asio io_service.
+         *  @param  strand     A weak pointer to a io_service::strand instance.
          */
         Timer(boost::asio::io_service &io_service,
               const std::weak_ptr<boost::asio::io_service::strand> strand) :

--- a/include/libboostasio.h
+++ b/include/libboostasio.h
@@ -3,9 +3,11 @@
  *
  *  Implementation for the AMQP::TcpHandler that is optimized for boost::asio. You can
  *  use this class instead of a AMQP::TcpHandler class, just pass the boost asio service
- *  to the constructor and you're all set
+ *  to the constructor and you're all set.  See tests/libboostasio.cpp for example.
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
+ *
+ *
  */
 
 /**
@@ -19,9 +21,10 @@
 #include <memory>
 
 #include <boost/asio/io_service.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/bind.hpp>
-#include <boost/function.hpp>
 
 
 ///////////////////////////////////////////////////////////////////
@@ -78,7 +81,7 @@ private:
          *  @var class boost::asio::io_service&
          */
         boost::asio::io_service & _ioservice;
-        
+
         /**
          *  The boost asio io_service::strand managed pointer.
          *  @var class std::shared_ptr<boost::asio::io_service>
@@ -127,7 +130,7 @@ private:
          *  @note   The handler will get called if a read is cancelled.
          */
         void read_handler(const boost::system::error_code &ec,
-						  const std::size_t bytes_transferred,
+                          const std::size_t bytes_transferred,
                           const std::weak_ptr<Watcher> awpWatcher,
                           TcpConnection *const connection,
                           const int fd)
@@ -144,8 +147,8 @@ private:
                 connection->process(fd, AMQP::readable);
 
                 _read_pending = true;
-                
-                _socket.async_read_some(boost::asio::null_buffers(), 
+
+                _socket.async_read_some(boost::asio::null_buffers(),
                                         STRAND_SOCKET_HANDLER(
                                             boost::bind(&Watcher::read_handler,
                                             this,
@@ -313,13 +316,13 @@ private:
          *  @var class boost::asio::io_service&
          */
         boost::asio::io_service & _ioservice;
-        
+
         /**
          *  The boost asio io_service::strand managed pointer.
          *  @var class std::shared_ptr<boost::asio::io_service>
          */
         std::weak_ptr<boost::asio::io_service::strand> _strand;
-        
+
         /**
          *  The boost asynchronous deadline timer.
          *  @var class boost::asio::deadline_timer
@@ -483,7 +486,7 @@ private:
 				std::make_shared<Watcher>(_ioservice, _strand, fd);
 
             _watchers[fd] = apWatcher;
-            
+
             // explicitly set the events to monitor
             apWatcher->events(connection, fd, flags);
         }

--- a/include/libboostasio.h
+++ b/include/libboostasio.h
@@ -33,8 +33,8 @@
     if (!apStrand)                                                                              \
     {                                                                                           \
         fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled),std::size_t{0}); \
-		return;                                                                                 \
-	}                                                                                           \
+        return;                                                                                 \
+    }                                                                                           \
                                                                                                 \
     apStrand->dispatch(boost::bind(fn,ec,bytes_transferred));                                   \
 }
@@ -47,8 +47,8 @@
     if (!apStrand)                                                                              \
     {                                                                                           \
         fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));      \
-		return;                                                                                 \
-	}                                                                                           \
+        return;                                                                                 \
+    }                                                                                           \
                                                                                                 \
     apStrand->dispatch(boost::bind(fn,ec));                                                     \
 }

--- a/tests/libboostasio.cpp
+++ b/tests/libboostasio.cpp
@@ -1,0 +1,59 @@
+/**
+ *  LibBoostAsio.cpp
+ * 
+ *  Test program to check AMQP functionality based on Boost's asio io_service.
+ * 
+ *  @author Gavin Smith <gavin.smith@coralbay.tv>
+ *
+ *  Compile with g++ libboostasio.cpp -o boost_test -lpthread -lboost_system -lamqpcpp
+ */
+
+/**
+ *  Dependencies
+ */
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/asio/deadline_timer.hpp>
+
+
+#include <amqpcpp.h>
+#include <amqpcpp/libboostasio.h>
+
+/**
+ *  Main program
+ *  @return int
+ */
+int main()
+{
+
+    // access to the boost asio handler
+    // note: we suggest use of 2 threads - normally one is fin (we are simply demonstrating thread safety).
+    boost::asio::io_service service(4);
+
+    // create a work object to process our events.
+    boost::asio::io_service::work work(service);
+    
+    // handler for libev
+    AMQP::LibBoostAsioHandler handler(service);
+    
+    // make a connection
+    AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://guest:guest@localhost/"));
+    
+    // we need a channel too
+    AMQP::TcpChannel channel(&connection);
+    
+    // create a temporary queue
+    channel.declareQueue(AMQP::exclusive).onSuccess([&connection](const std::string &name, uint32_t messagecount, uint32_t consumercount) {
+        
+        // report the name of the temporary queue
+        std::cout << "declared queue " << name << std::endl;
+        
+        // now we can close the connection
+        connection.close();
+    });
+    
+    // run the handler
+    // a t the moment, one will need SIGINT to stop.  In time, should add signal handling through boost API.
+    return service.run();
+}
+


### PR DESCRIPTION
Added a boost io::service_strand to LibBoostAsioHandler to make the AMQP-CPP handler thread safe when a boost::asio::io_service is used that is specifically utilising more than a single thread for its pool.

This code has been tested.