### PR TITLE
Added missing include for "boost/function.hpp" in libboostasio.h.

### DIFF
--- a/include/libboostasio.h
+++ b/include/libboostasio.h
@@ -28,11 +28,11 @@
 #include <boost/function.hpp>
 
 // C++17 has 'weak_from_this()' support.
-#if __cplusplus >= 201701L
-#define PTR_FROM_THIS weak_from_this
-#else
+//#if __cplusplus >= 201701L
+//#define PTR_FROM_THIS weak_from_this
+//#else
 #define PTR_FROM_THIS shared_from_this
-#endif
+//#endif
 
 /**
  *  Set up namespace

--- a/include/libboostasio.h
+++ b/include/libboostasio.h
@@ -25,6 +25,7 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/bind.hpp>
+#include <boost/function.hpp>
 
 // C++17 has 'weak_from_this()' support.
 #if __cplusplus >= 201701L


### PR DESCRIPTION
The 'libboostasio.h' file requires boost::function but is not imported directly in the file.