### PR TITLE
Add returned message support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,15 +803,13 @@ in almost any form:
  *  The following flags can be used
  *
  *      -   mandatory   if set, an unroutable message will be sent back to
- *                      the client (currently not supported)
+ *                      the client
  *
  *      -   immediate   if set, a message that could not immediately be consumed
- *                      is returned to the client (currently not supported)
+ *                      is returned to the client
  *
  *  If either of the two flags is set, and the message could not immediately
- *  be published, the message is returned by the server to the client. However,
- *  at this moment in time, the AMQP-CPP library does not support catching
- *  such returned messages.
+ *  be published, the message is returned by the server to the client.
  *
  *  @param  exchange    the exchange to publish to
  *  @param  routingkey  the routing key
@@ -820,13 +818,26 @@ in almost any form:
  *  @param  message     the message to send
  *  @param  size        size of the message
  */
-bool publish(const std::string &exchange, const std::string &routingKey, int flags, const AMQP::Envelope &envelope);
-bool publish(const std::string &exchange, const std::string &routingKey, const AMQP::Envelope &envelope);
-bool publish(const std::string &exchange, const std::string &routingKey, int flags, const std::string &message);
-bool publish(const std::string &exchange, const std::string &routingKey, const std::string &message);
-bool publish(const std::string &exchange, const std::string &routingKey, int flags, const char *message, size_t size);
-bool publish(const std::string &exchange, const std::string &routingKey, const char *message, size_t size);
+bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope, int flags = 0);
+bool publish(const std::string &exchange, const std::string &routingKey, const std::string &message, int flags = 0);
+bool publish(const std::string &exchange, const std::string &routingKey, const char *message, size_t size, int flags = 0);
+bool publish(const std::string &exchange, const std::string &routingKey, const char *message, int flags = 0);
 ````
+
+To get notified of any unroutable messages you can register a callback to be
+invoked for every unroutable message. It is registered in the callbacks.h
+file as ReturnCallback.
+
+````c++
+ReturnCallback cb = [](int16_t replyCode, const std::string &replyText,
+    const std::string &exchange, const std::string &routingKey,
+    const Message &message) {
+        // process unroutable message
+    }
+
+channel.onReturn(cb);
+````
+
 
 Published messages are normally not confirmed by the server, and the RabbitMQ
 will not send a report back to inform you whether the message was succesfully
@@ -1002,7 +1013,6 @@ need additional attention:
     -   ability to set up secure connections (or is this fully done on the IO level)
     -   login with other protocols than login/password
     -   publish confirms
-    -   returned messages
 
 We also need to add more safety checks so that strange or invalid data from
 RabbitMQ does not break the library (although in reality RabbitMQ only sends

--- a/include/amqpcpp/callbacks.h
+++ b/include/amqpcpp/callbacks.h
@@ -48,6 +48,7 @@ using DeleteCallback    =   std::function<void(uint32_t deletedmessages)>;
 using SizeCallback      =   std::function<void(uint32_t messagecount)>;
 using ConsumeCallback   =   std::function<void(const std::string &consumer)>;
 using CancelCallback    =   std::function<void(const std::string &consumer)>;
+using ReturnCallback    =   std::function<void(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message)>;
 
 /**
  *  End namespace

--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -90,6 +90,20 @@ public:
     }
 
     /**
+     *  Callback that is called when a message publish fail occurs.
+     *  This callback will be called with the returned message.
+     *
+     *  Only one callback can be registered. Calling this function
+     *  multiple times will remove the old callback.
+     *
+     *  @param  callback    the callback to execute
+     */
+    void onReturn(const ReturnCallback &callback)
+    {
+        _implementation->onReturn(callback);
+    }
+
+    /**
      *  Pause deliveries on a channel
      *
      *  This will stop all incoming messages
@@ -348,10 +362,10 @@ public:
      *  @param  message     the message to send
      *  @param  size        size of the message
      */
-    bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope) { return _implementation->publish(exchange, routingKey, envelope); }
-    bool publish(const std::string &exchange, const std::string &routingKey, const std::string &message) { return _implementation->publish(exchange, routingKey, Envelope(message.data(), message.size())); }
-    bool publish(const std::string &exchange, const std::string &routingKey, const char *message, size_t size) { return _implementation->publish(exchange, routingKey, Envelope(message, size)); }
-    bool publish(const std::string &exchange, const std::string &routingKey, const char *message) { return _implementation->publish(exchange, routingKey, Envelope(message, strlen(message))); }
+    bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope, int flags = 0) { return _implementation->publish(exchange, routingKey, envelope, flags); }
+    bool publish(const std::string &exchange, const std::string &routingKey, const std::string &message, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message.data(), message.size()), flags); }
+    bool publish(const std::string &exchange, const std::string &routingKey, const char *message, size_t size, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message, size), flags); }
+    bool publish(const std::string &exchange, const std::string &routingKey, const char *message, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message, strlen(message)), flags); }
 
     /**
      *  Set the Quality of Service (QOS) for this channel

--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -36,6 +36,7 @@ namespace AMQP {
  */
 class DeferredConsumerBase;
 class BasicDeliverFrame;
+class BasicReturnFrame;
 class DeferredConsumer;
 class BasicGetOKFrame;
 class ConsumedMessage;
@@ -135,6 +136,12 @@ private:
     std::shared_ptr<DeferredConsumerBase> _consumer;
 
     /**
+     *  The returned consumer
+     *  @var    std::shared_ptr<DeferredConsumerBase>
+     */
+    std::shared_ptr<DeferredConsumerBase> _returnConsumer;
+
+    /**
      *  Attach the connection
      *  @param  connection
      */
@@ -215,6 +222,16 @@ public:
      *  @param  callback    the callback to execute
      */
     void onError(const ErrorCallback &callback);
+
+    /**
+     *  Callback that is called when a message publish fail occurs.
+     *
+     *  Only one callback can be registered. Calling this function
+     *  multiple times will remove the old callback.
+     *
+     *  @param  callback    the callback to execute
+     */
+    void onReturn(const ReturnCallback &callback);
 
     /**
      *  Pause deliveries on a channel
@@ -404,8 +421,9 @@ public:
      *  @param  envelope    the full envelope to send
      *  @param  message     the message to send
      *  @param  size        size of the message
+     *  @param  flags       message publish flags
      */
-    bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope);
+    bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope, int flags = 0);
 
     /**
      *  Set the Quality of Service (QOS) of the entire connection
@@ -689,6 +707,13 @@ public:
      *  @param  frame   The frame to process
      */
     void process(BasicDeliverFrame &frame);
+
+    /**
+     *  Process incoming returned
+     *
+     *  @param frame The frame to process
+     */
+    void process(BasicReturnFrame &frame);
 
     /**
      *  Retrieve the current consumer handler

--- a/include/amqpcpp/deferredconsumer.h
+++ b/include/amqpcpp/deferredconsumer.h
@@ -49,6 +49,16 @@ private:
     virtual void announce(const Message &message, uint64_t deliveryTag, bool redelivered) const override;
 
     /**
+     *  Announce that a message has been returned
+     *  @param replyCode The reply code
+     *  @param replyText The reply text
+     *  @param exchange The exchange the message was published to
+     *  @param routingKey The routing key
+     *  @param message The returned message
+     */
+    virtual void announce_return(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message) const override;
+
+    /**
      *  The channel implementation may call our
      *  private members and construct us
      */
@@ -216,6 +226,14 @@ public:
         // allow chaining
         return *this;
     }
+
+    /**
+     *  Register a function to be called when a message was unroutable by the server
+     *
+     *  @param callback The callback to invoke
+     *  @return Same object for chaining
+     */
+    DeferredConsumer &onReturn(const ReturnCallback &callback);
 };
 
 /**

--- a/include/amqpcpp/deferredconsumerbase.h
+++ b/include/amqpcpp/deferredconsumerbase.h
@@ -30,6 +30,7 @@ namespace AMQP {
 class BasicDeliverFrame;
 class BasicGetOKFrame;
 class BasicHeaderFrame;
+class BasicReturnFrame;
 class BodyFrame;
 
 /**
@@ -68,6 +69,13 @@ private:
     void process(BasicHeaderFrame &frame);
 
     /**
+     *  Process incoming return
+     *
+     *  @param  frame   The frame to process
+     */
+    void process(BasicReturnFrame &frame);
+
+    /**
      *  Process the message data
      *
      *  @param  frame   The frame to process
@@ -86,6 +94,16 @@ private:
      *  @param  redelivered Is this a redelivered message
      */
     virtual void announce(const Message &message, uint64_t deliveryTag, bool redelivered) const = 0;
+
+    /**
+     *  Announce that a message has been returned
+     *  @param replyCode The reply code
+     *  @param replyText The reply text
+     *  @param exchange The exchange the message was published to
+     *  @param routingKey The routing key
+     *  @param message The returned message
+     */
+    virtual void announce_return(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message) const = 0;
 
     /**
      *  Frames may be processed
@@ -107,6 +125,18 @@ protected:
      *  @var    bool
      */
     bool _redelivered = false;
+
+    /**
+     *  The reply code for the current message
+     *  @var    int16_t
+     */
+    int16_t _replyCode = 0;
+
+    /**
+     *  The reply text for the current message
+     *  @var std::string
+     */
+    std::string _replyText;
 
     /**
      *  The channel to which the consumer is linked
@@ -143,6 +173,12 @@ protected:
      *  @var    CompleteCallback
      */
     CompleteCallback _completeCallback;
+
+    /**
+     *  Callback for when a message was returned and undelivered
+     *  @var    ReturnedCallback
+     */
+    ReturnCallback _returnCallback;
 
     /**
      *  The message that we are currently receiving

--- a/include/amqpcpp/deferredget.h
+++ b/include/amqpcpp/deferredget.h
@@ -65,6 +65,16 @@ private:
     virtual void announce(const Message &message, uint64_t deliveryTag, bool redelivered) const override;
 
     /**
+     *  Announce that a message has been returned
+     *  @param replyCode The reply code
+     *  @param replyText The reply text
+     *  @param exchange The exchange the message was published to
+     *  @param routingKey The routing key
+     *  @param message The returned message
+     */
+    virtual void announce_return(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message) const override;
+
+    /**
      *  The channel implementation may call our
      *  private members and construct us
      */

--- a/src/basicreturnframe.h
+++ b/src/basicreturnframe.h
@@ -155,8 +155,17 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
-        // we no longer support returned messages
-        return false;
+        // we need the appropriate channel
+        auto channel = connection->channel(this->channel());
+
+        // channel does not exist
+        if (!channel) return false;
+
+        // construct the message
+        channel->process(*this);
+
+        // done
+        return true;
     }
 };
 

--- a/src/deferredconsumer.cpp
+++ b/src/deferredconsumer.cpp
@@ -45,6 +45,38 @@ void DeferredConsumer::announce(const Message &message, uint64_t deliveryTag, bo
 }
 
 /**
+ *  Announce that a message has been returned
+ *  @param returnCode The return code
+ *  @param returnText The return text
+ *  @param exchange The exchange the message was published to
+ *  @param routingKey The routing key
+ *  @param message The returned message
+ */
+void DeferredConsumer::announce_return(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message) const
+{
+	if (_returnCallback)
+	{
+    	// simply execute the return callback
+    	_returnCallback(replyCode, replyText, exchange, routingKey, message);
+	}
+}
+
+/**
+ *  Register a function to be called when a message was unroutable by the server
+ *
+ *  @param callback The callback to invoke
+ *  @return Same object for chaining
+ */
+DeferredConsumer &DeferredConsumer::onReturn(const ReturnCallback &callback)
+{
+    // store callback
+    _returnCallback = callback;
+
+    // allow chaining
+    return *this;
+}
+
+/**
  *  End namespace
  */
 }

--- a/src/deferredget.cpp
+++ b/src/deferredget.cpp
@@ -82,6 +82,32 @@ void DeferredGet::announce(const Message &message, uint64_t deliveryTag, bool re
 }
 
 /**
+ *  Announce that a message has been returned
+ *  @param returnCode The return code
+ *  @param returnText The return text
+ *  @param exchange The exchange the message was published to
+ *  @param routingKey The routing key
+ *  @param message The returned message
+ */
+void DeferredGet::announce_return(int16_t replyCode, const std::string &replyText, const std::string &exchange, const std::string &routingKey, const Message &message) const
+{
+    // monitor the channel
+    Monitor monitor{ _channel };
+
+    // the channel is now synchronized
+    _channel->onSynchronized();
+
+    // simply execute the returned callback
+    _returnCallback(replyCode, replyText, exchange, routingKey, std::move(message));
+
+    // check if the channel is still valid
+    if (!monitor.valid()) return;
+
+    // stop consuming now
+    _channel->uninstall({});
+}
+
+/**
  *  End of namespace
  */
 }


### PR DESCRIPTION
Added support to handle returned messages.
These are messages that are published with the mandatory or immediate flag set.
If any of these message are unroutable they will be returned to the client and processed.

A new callback type called ReturnCallback has been added for these messages.
This callback gets registered on the AMQP::Channel via onReturn()