### PR TITLE
SSL Linking

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(amqpcpp_boost_example libboostasio.cpp)
 
 add_dependencies(amqpcpp_boost_example amqpcpp)
 
-target_link_libraries(amqpcpp_boost_example amqpcpp boost_system pthread)
+target_link_libraries(amqpcpp_boost_example amqpcpp boost_system pthread dl ssl)
 
 ###################################
 # Libev
@@ -18,7 +18,7 @@ add_executable(amqpcpp_libev_example libev.cpp)
 
 add_dependencies(amqpcpp_libev_example amqpcpp)
 
-target_link_libraries(amqpcpp_libev_example amqpcpp ev pthread)
+target_link_libraries(amqpcpp_libev_example amqpcpp ev pthread dl ssl)
 
 
 ###################################
@@ -29,4 +29,4 @@ add_executable(amqpcpp_libuv_example libuv.cpp)
 
 add_dependencies(amqpcpp_libuv_example amqpcpp)
 
-target_link_libraries(amqpcpp_libuv_example amqpcpp uv pthread)
+target_link_libraries(amqpcpp_libuv_example amqpcpp uv pthread dl ssl)

--- a/src/linux_tcp/CMakeLists.txt
+++ b/src/linux_tcp/CMakeLists.txt
@@ -1,7 +1,13 @@
 add_sources(
     addressinfo.h
     includes.h
+    openssl.cpp
+    openssl.h
     pipe.h
+    sslconnected.h
+    sslcontext.h
+    sslhandshake.h
+    sslwrapper.h
     tcpclosed.h
     tcpconnected.h
     tcpconnection.cpp


### PR DESCRIPTION
I was having linking trouble with the recent OpenSSL extensions. It didn't even build `openssl.cpp`, but ssl was needed due to inclusion in the `TcpResolver`.

I added the missing files to CMake and libraries.

I'm fairly sure you really want OpenSSL to be an optional dependency. But at least this PR lets me build and link the examples.