### PR TITLE
Fix shutdown issues with libboostasio

### DIFF
--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -30,9 +30,6 @@ int main()
     // note: we suggest use of 2 threads - normally one is fin (we are simply demonstrating thread safety).
     boost::asio::io_service service(4);
 
-    // create a work object to process our events.
-    boost::asio::io_service::work work(service);
-    
     // handler for libev
     AMQP::LibBoostAsioHandler handler(service);
     

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -36,9 +36,9 @@
 
 // C++17 has 'weak_from_this()' support.
 #if __cplusplus >= 201701L
-#define PTR_FROM_THIS weak_from_this
+#define PTR_FROM_THIS(T) weak_from_this()
 #else
-#define PTR_FROM_THIS shared_from_this
+#define PTR_FROM_THIS(T) std::weak_ptr<T>(shared_from_this())
 #endif
 
 /**
@@ -142,7 +142,7 @@ protected:
                                   this,
                                   _1,
                                   _2,
-                                  PTR_FROM_THIS(),
+                                  PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
             return get_dispatch_wrapper(fn);
@@ -160,7 +160,7 @@ protected:
                                   this,
                                   _1,
                                   _2,
-                                  PTR_FROM_THIS(),
+                                  PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
             return get_dispatch_wrapper(fn);
@@ -346,7 +346,7 @@ protected:
             const auto fn = boost::bind(&Timer::timeout,
                                   this,
                                   _1,
-                                  PTR_FROM_THIS(),
+                                  PTR_FROM_THIS(Timer),
                                   connection,
                                   timeout);
 
@@ -583,6 +583,16 @@ public:
      *  Destructor
      */
     ~LibBoostAsioHandler() override = default;
+
+    /**
+     * Make sure to stop the heartbeat timer after the connection is closed.
+     * Otherwise it will keep the service running forever.
+     */
+    void onClosed(TcpConnection* connection) override
+    {
+        (void)connection;
+        _timer.reset();
+    }
 };
 
 


### PR DESCRIPTION
Fixes #197. Note that the example was still not stopping the main loop because a manual work object was created. This should not be necessary. @zerodefect 