### PR TITLE
Simplify inclusion as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set (CMAKE_CXX_STANDARD 11)
 # ------------------------------------------------------------------------------------------------------
 
 # set include/ as include directory
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # macro that adds a list of provided source files to a list called SRCS.
 # if variable SRCS does not yet exist, it is created.
@@ -69,7 +69,7 @@ endif()
 # ------------------------------------------------------------------------------------------------------
 
 # set output directory
-set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 if(AMQP-CPP_BUILD_SHARED)
     # create shared lib

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ On Windows you are required to define `NOMINMAX` when compiling code that includ
 ## Using cmake
 
 The CMake file supports both building and installing. You can choose not to use 
-the install functionality, and instead manually use the build output at `bin/`. Keep 
+the install functionality, and instead manually use the build output at `build/bin/`. Keep
 in mind that the TCP module is only supported for Linux. An example install method 
 would be:
 


### PR DESCRIPTION
The patch changes build scripts to use not root, but current directories, which simplifies using this project as a CMake subproject. When included somewhere, `${CMAKE_SOURCE_DIR}` variables points to the source directory of a parent project, while `${CMAKE_CURRENT_SOURCE_DIR}` still points to the right place.

Another thing is installing generated library to the source directory. Having a separate directory makes it easier to spot the generated output, since it's not polluted by CMake-generated files. But it's still appears in a sources directory, which may surprise. The patch proposes to move it to the `build/bin/`. It's still a clean subdirectory, but at the same moment is located in build subtree, where it's expected the most.