### PR TITLE
Add method to return the amount of queued outgoing data

### DIFF
--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -123,6 +123,12 @@ public:
     int fileno() const;
 
     /**
+     *  The number of outgoing bytes queued on this connection.
+     *  @return size_t
+     */
+    size_t bytesQueued() const;
+
+    /**
      *  Process the TCP connection
      * 
      *  This method should be called when the filedescriptor that is registered

--- a/src/linux_tcp/sslconnected.h
+++ b/src/linux_tcp/sslconnected.h
@@ -335,6 +335,12 @@ public:
      *  @return int
      */
     virtual int fileno() const override { return _socket; }
+
+    /**
+     *  The number of outgoing bytes queued on this connection.
+     *  @return size_t
+     */
+    virtual size_t bytesQueued() const { return _out.size(); }
      
     /**
      *  Process the filedescriptor in the object

--- a/src/linux_tcp/tcpconnected.h
+++ b/src/linux_tcp/tcpconnected.h
@@ -157,7 +157,13 @@ public:
      *  @return int
      */
     virtual int fileno() const override { return _socket; }
-    
+
+    /**
+     *  The number of outgoing bytes queued on this connection.
+     *  @return size_t
+     */
+    virtual size_t bytesQueued() const { return _out.size(); }
+
     /**
      *  Process the filedescriptor in the object
      *  @param  monitor     Monitor to check if the object is still alive

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -44,6 +44,15 @@ int TcpConnection::fileno() const
 }
 
 /**
+ *  The number of outgoing bytes queued on this connection.
+ *  @return size_t
+ */
+size_t TcpConnection::bytesQueued() const
+{
+    return _state->bytesQueued();
+}
+
+/**
  *  Process the TCP connection
  *  This method should be called when the filedescriptor that is registered
  *  in the event loop becomes active. You should pass in a flag holding the

--- a/src/linux_tcp/tcpstate.h
+++ b/src/linux_tcp/tcpstate.h
@@ -64,6 +64,12 @@ public:
     virtual int fileno() const { return -1; }
 
     /**
+     *  The number of outgoing bytes queued on this connection.
+     *  @return size_t
+     */
+    virtual size_t bytesQueued() const { return 0; }
+
+    /**
      *  Process the filedescriptor in the object
      * 
      *  This method should return the handler object that will be responsible for


### PR DESCRIPTION
I have a program which needs to publish a large number of messages and then exit.

Exiting after calling AMQP::Channel::publish() for the last time doesn't work, because most of the messages are still queued within libamqpcpp. I need to wait for them all to go out on the wire before shutting down.

If I patch my program so that it never exits, all the messages eventually reach RabbitMQ and the rest of the system works perfectly. However my program's peak memory consumption is enormous.

This change adds the TcpConnection::bytesQueued() method which returns the number of bytes currently waiting to be sent across the TCP connection. Monitoring its return value solves both of my problems, and might be useful for others too.
