### PR TITLE
Envelope: ensure const objects cannot be changed through _body

### DIFF
--- a/include/amqpcpp/envelope.h
+++ b/include/amqpcpp/envelope.h
@@ -32,7 +32,7 @@ protected:
      *  Pointer to the body data (the memory is not managed by the AMQP library!)
      *  @var    const char *
      */
-    char *_body;
+    const char *_body;
 
     /**
      *  Size of the data
@@ -40,12 +40,6 @@ protected:
      */
     uint64_t _bodySize;
     
-    /**
-     *  Was the data allocated by this object?
-     *  @var    bool
-     */
-    bool _allocated = false;
-
 public:
     /**
      *  Constructor
@@ -56,7 +50,7 @@ public:
      *  @param  body
      *  @param  size
      */
-    Envelope(const char *body, uint64_t size) : MetaData(), _body(const_cast<char *>(body)), _bodySize(size) {}
+    Envelope(const char *body, uint64_t size) : MetaData(), _body(body), _bodySize(size) {}
 
     /**
      *  Disabled copy constructor
@@ -68,11 +62,7 @@ public:
     /**
      *  Destructor
      */
-    virtual ~Envelope()
-    {
-        // deallocate the data
-        if (_allocated) free(_body);
-    }
+    virtual ~Envelope() {}
 
     /**
      *  Access to the full message data


### PR DESCRIPTION
In commit 00b81949d3736470362e9f5b5324b8e1973867bb where Message and
Envelope objects were made uncopiable the Envelope _body member was
changed from const char * to char * and a const_cast introduced to
remove the qualifier from the pointer passed to the constructor.

This technically produces undefined behavior when constructing an
Envelope() to publish data from a const buffer.  It also risks future
bugs if a new subclass of Envelope mutates const objects through the
_body pointer.

Envelope does not need to support mutable or owned content.  Move this
capability down to Message which is used in restricted situations where
the body size is set once and its content built up piecewise.