### PR TITLE
Fix MSVC compile warnings

### DIFF
--- a/include/amqpcpp/callbacks.h
+++ b/include/amqpcpp/callbacks.h
@@ -45,7 +45,7 @@ using DeleteCallback        =   std::function<void(uint32_t deletedmessages)>;
  *  When retrieving the size of a queue in some way
  */
 using EmptyCallback         =   std::function<void()>;
-using SizeCallback          =   std::function<void(uint32_t messagecount)>;
+using SizeCallback          =   std::function<void(uint64_t messagecount)>;
 
 /**
  *  Starting and stopping a consumer

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -261,11 +261,11 @@ Deferred &ChannelImpl::declareExchange(const std::string &name, ExchangeType typ
     else if (type == ExchangeType::consistent_hash) exchangeType = "x-consistent-hash";
 
     // the boolean options
-    bool passive = flags & AMQP::passive;
-    bool durable = flags & AMQP::durable;
-    bool autodelete = flags & AMQP::autodelete;
-    bool internal = flags & AMQP::internal;
-    bool nowait = flags & AMQP::nowait;
+    bool passive = (flags & AMQP::passive) != 0;
+    bool durable = (flags & AMQP::durable) != 0;
+    bool autodelete = (flags & AMQP::autodelete) != 0;
+    bool internal = (flags & AMQP::internal) != 0;
+    bool nowait = (flags & AMQP::nowait) != 0;
 
     // send declare exchange frame
     return push(ExchangeDeclareFrame(_id, name, exchangeType, passive, durable, autodelete, internal, nowait, arguments));


### PR DESCRIPTION
Fix MSVC compile warning **C4800** for bitwise operation resulting in int to boolean assignment.
Fix MSVC compile warning **C4244** possible loss of data. Possible data loss from uint64_t to uint32_t.