### PR TITLE
Fix msvc compiler warnings

### DIFF
--- a/include/amqpcpp/callbacks.h
+++ b/include/amqpcpp/callbacks.h
@@ -45,7 +45,7 @@ using DeleteCallback        =   std::function<void(uint32_t deletedmessages)>;
  *  When retrieving the size of a queue in some way
  */
 using EmptyCallback         =   std::function<void()>;
-using SizeCallback          =   std::function<void(uint32_t messagecount)>;
+using SizeCallback          =   std::function<void(uint64_t messagecount)>;
 
 /**
  *  Starting and stopping a consumer

--- a/include/amqpcpp/callbacks.h
+++ b/include/amqpcpp/callbacks.h
@@ -45,7 +45,8 @@ using DeleteCallback        =   std::function<void(uint32_t deletedmessages)>;
  *  When retrieving the size of a queue in some way
  */
 using EmptyCallback         =   std::function<void()>;
-using SizeCallback          =   std::function<void(uint64_t messagecount)>;
+using CountCallback         =   std::function<void(uint32_t messagecount)>;
+using SizeCallback          =   std::function<void(uint64_t messagesize)>;
 
 /**
  *  Starting and stopping a consumer

--- a/include/amqpcpp/deferredget.h
+++ b/include/amqpcpp/deferredget.h
@@ -38,9 +38,9 @@ private:
 
     /**
      *  Callback with the number of messages still in the queue
-     *  @var    SizeCallback
+     *  @var    CountCallback
      */
-    SizeCallback _countCallback;
+    CountCallback _countCallback;
 
     /**
      *  Report success for a get operation
@@ -149,7 +149,7 @@ public:
      *  Register a function to be called when queue size information is known
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onCount(const SizeCallback &callback)
+    DeferredGet &onCount(const CountCallback &callback)
     {
         // store callback
         _countCallback = callback;

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -261,11 +261,11 @@ Deferred &ChannelImpl::declareExchange(const std::string &name, ExchangeType typ
     else if (type == ExchangeType::consistent_hash) exchangeType = "x-consistent-hash";
 
     // the boolean options
-    bool passive = flags & AMQP::passive;
-    bool durable = flags & AMQP::durable;
-    bool autodelete = flags & AMQP::autodelete;
-    bool internal = flags & AMQP::internal;
-    bool nowait = flags & AMQP::nowait;
+    bool passive = (flags & AMQP::passive) != 0;
+    bool durable = (flags & AMQP::durable) != 0;
+    bool autodelete = (flags & AMQP::autodelete) != 0;
+    bool internal = (flags & AMQP::internal) != 0;
+    bool nowait = (flags & AMQP::nowait) != 0;
 
     // send declare exchange frame
     return push(ExchangeDeclareFrame(_id, name, exchangeType, passive, durable, autodelete, internal, nowait, arguments));


### PR DESCRIPTION
Fix MSVC compile warning C4800 for bitwise operation resulting in int to boolean assignment.

Added CountCallback for deferred get where message count is passed as uint32_t. @pabigot recommendation.

Updated SizeCallback to use uint64_t as it is used when message size is passed.

SizeCallback was updated as there was a compile warning C4244 possible loss of data. Possible data loss from uint64_t to uint32_t. This was when the SizeCallback was called in the deferred receiver.