### PR TITLE
Clear SSL Error Queue

### DIFF
--- a/src/linux_tcp/openssl.cpp
+++ b/src/linux_tcp/openssl.cpp
@@ -311,6 +311,19 @@ int SSL_use_certificate_file(SSL *ssl, const char *file, int type)
 }
 
 /**
+ *  Clear the SSL error queue
+ *  @return void
+ */
+void ERR_clear_error()
+{
+    // create a function
+    static Function<decltype(::ERR_clear_error)> func(handle, "ERR_clear_error");
+
+    // call the openssl function
+    return func();
+}
+
+/**
  *  End of namespace
  */
 }}

--- a/src/linux_tcp/openssl.h
+++ b/src/linux_tcp/openssl.h
@@ -18,6 +18,7 @@
  *  Dependencies
  */
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 
 /**
  *  Begin of namespace
@@ -49,6 +50,7 @@ void     SSL_set_connect_state(SSL *ssl);
 void     SSL_CTX_free(SSL_CTX *ctx);
 void     SSL_free(SSL *ssl);
 long     SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg);
+void     ERR_clear_error(void);
 
 /**
  *  End of namespace


### PR DESCRIPTION
The OpenSSL documentation states that the error queue for the current
thread needs to be emptied prior to the next TLS/SSL I/O operation,
or the call to SSL_get_error() will not be reliable.