### PR TITLE
Fixed unused parameter warnings in header files

### DIFF
--- a/include/amqpcpp/bytebuffer.h
+++ b/include/amqpcpp/bytebuffer.h
@@ -114,6 +114,7 @@ public:
      */
     virtual const char *data(size_t pos, size_t size) const override
     {
+        (void) size;
         return _data + pos;
     }
     

--- a/include/amqpcpp/connectionhandler.h
+++ b/include/amqpcpp/connectionhandler.h
@@ -63,6 +63,8 @@ public:
     virtual uint16_t onNegotiate(Connection *connection, uint16_t interval)
     {
         // default implementation, disable heartbeats
+        (void) connection;
+        (void) interval;
         return 0;
     }
 
@@ -88,7 +90,7 @@ public:
      *
      *  @param  connection      The connection over which the heartbeat was received
      */
-    virtual void onHeartbeat(Connection *connection) {}
+    virtual void onHeartbeat(Connection *connection) { (void) connection; }
 
     /**
      *  When the connection ends up in an error state this method is called.
@@ -104,7 +106,11 @@ public:
      *  @param  connection      The connection that entered the error state
      *  @param  message         Error message
      */
-    virtual void onError(Connection *connection, const char *message) {}
+    virtual void onError(Connection *connection, const char *message)
+    {
+        (void) connection;
+        (void) message;
+    }
 
     /**
      *  Method that is called when the login attempt succeeded. After this method
@@ -120,7 +126,7 @@ public:
      *
      *  @param  connection      The connection that can now be used
      */
-    virtual void onConnected(Connection *connection) {}
+    virtual void onConnected(Connection *connection) { (void) connection; }
 
     /**
      *  Method that is called when the connection was closed.
@@ -130,7 +136,7 @@ public:
      *
      *  @param  connection      The connection that was closed and that is now unusable
      */
-    virtual void onClosed(Connection *connection) {}
+    virtual void onClosed(Connection *connection) { (void) connection; }
 
 };
 

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -98,6 +98,9 @@ protected:
     virtual const std::shared_ptr<Deferred> &reportSuccess(const std::string &name, uint32_t messagecount, uint32_t consumercount) const
     {
         // this is the same as a regular success message
+        (void) name;
+        (void) messagecount;
+        (void) consumercount;
         return reportSuccess();
     }
 
@@ -109,6 +112,7 @@ protected:
     virtual const std::shared_ptr<Deferred> &reportSuccess(uint32_t messagecount) const
     {
         // this is the same as a regular success message
+        (void) messagecount;
         return reportSuccess();
     }
 
@@ -122,6 +126,9 @@ protected:
     virtual const std::shared_ptr<Deferred> &reportSuccess(uint32_t messagecount, uint64_t deliveryTag, bool redelivered)
     {
         // this is the same as a regular success message
+        (void) messagecount;
+        (void) deliveryTag;
+        (void) redelivered;
         return reportSuccess();
     }
 
@@ -133,6 +140,7 @@ protected:
     virtual const std::shared_ptr<Deferred> &reportSuccess(const std::string &name)
     {
         // this is the same as a regular success message
+        (void) name;
         return reportSuccess();
     }
 

--- a/include/amqpcpp/frame.h
+++ b/include/amqpcpp/frame.h
@@ -90,6 +90,8 @@ public:
      */
     virtual bool process(ConnectionImpl *connection)
     {
+        (void) connection;
+
         // this is an exception
         throw ProtocolException("unimplemented frame");
 


### PR DESCRIPTION
Projects compiled with the compiler flags "-Wall -Wextra -Werror" cannot build when including AMQP-CPP because some of the header files contain function implementation with unused parameters.