### PR TITLE
Contint with gcc8/clang6 and Ubuntu Bionic LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ matrix:
       - COMPILER_PACKAGE=g++-7
       - C_COMPILER=gcc-7
       - CXX_COMPILER=g++-7
+      
+  - os: linux
+    compiler: gcc
+    env:
+      - COMPILER_PACKAGE=g++-8
+      - C_COMPILER=gcc-8
+      - CXX_COMPILER=g++-8
 
   ################
   # Linux / Clang
@@ -71,7 +78,7 @@ before_install:
   - uname -a
 
   # Use an artful container - gives us access to latest compilers.
-  - docker run -d --name ubuntu-test-container -v $(pwd):/travis ubuntu:artful tail -f /dev/null
+  - docker run -d --name ubuntu-test-container -v $(pwd):/travis ubuntu:bionic tail -f /dev/null
   - docker ps
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
       - CXXFLAGS=-std=c++11
 
   - os: linux
+    compiler: gcc
     env:
       - COMPILER_PACKAGE=g++-6
       - C_COMPILER=gcc-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,12 @@ matrix:
       - COMPILER_PACKAGE=clang-5.0
       - C_COMPILER=clang-5.0
       - CXX_COMPILER=clang++-5.0
+      
+  - os: linux
+    env:
+      - COMPILER_PACKAGE=clang-6.0
+      - C_COMPILER=clang-6.0
+      - CXX_COMPILER=clang++-6.0
 
 before_install:
 


### PR DESCRIPTION
Added support to build with both clang6 and gcc-8 (new compilers). In addition, now use Ubuntu's 18.04 LTS container (instead of defunct 17.10).