### PR TITLE
Clean shutdown after call to TcpConnection::close()

### DIFF
--- a/src/linux_tcp/tcpconnected.h
+++ b/src/linux_tcp/tcpconnected.h
@@ -177,6 +177,8 @@ public:
             
             // we can remove the reallocate instruction
             _reallocate = 0;
+
+            if(_closed) return new TcpClosed(_parent);
         }
         
         // keep same object

--- a/src/linux_tcp/tcpextstate.h
+++ b/src/linux_tcp/tcpextstate.h
@@ -30,7 +30,7 @@ protected:
     int _socket;
     
     /**
-     *  Clean-up the socket, and call the onClosed() method
+     *  Clean-up the socket, and call the onLost() method
      */
     void cleanup()
     {


### PR DESCRIPTION
In the following example, the program tries to receive data from the socket indefinitely after the `close()` call.

```
#include <amqpcpp.h>
#include <amqpcpp/libboostasio.h>

#include <boost/asio.hpp>
#include <boost/asio/deadline_timer.hpp>

#include <chrono>
#include <iostream>

int main()
{
    boost::asio::io_service io_service;

    AMQP::LibBoostAsioHandler handler(io_service);
    AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://localhost"));

    boost::asio::system_timer timer(io_service);
    timer.expires_from_now(std::chrono::seconds(10));
    timer.async_wait([&connection](auto error) {
        std::cerr << "Calling AMQP::TcpConnection::close()\n";
        connection.close();
        // after this lambda is executed, all async operations trigger by the main() code itself will be removed from
        // the io_service. So only AMQP could have operations left which delay the shutdown.
    });


    std::cerr << "Start event loop and connection...\n";
    io_service.run();
}
```

The issue seems to be that the `handler` is never notified about the closed connection and tries to read data even though there will be no more data transmitted from the server. When the CloseOK frame is received from the server, `TcpConnected::close()` will be called, but it still tries to read from the socket. This patch forcefully replaces the TcpState in the `process` method with TcpClosed, when the `TcpConnected::_closed` is set to true.