### PR TITLE
Adds a force parameter to Connection::heartbeat()

### DIFF
--- a/include/amqpcpp/connection.h
+++ b/include/amqpcpp/connection.h
@@ -96,11 +96,12 @@ public:
 
     /**
      *  Send a ping/heartbeat to the channel to keep it alive
-     *  @return bool
+     *  @param  force       always send the heartbeat, even if the connection is not idle
+     *  @return bool        returns false if the send of the heartbeat failed
      */
-    bool heartbeat()
+    bool heartbeat(bool force=false)
     {
-        return _implementation.heartbeat();
+        return _implementation.heartbeat(force);
     }
 
     /**


### PR DESCRIPTION
This change allows custom ConnectionHandler to control when the heartbeat is actually sent instead of having to work around the hidden idle state of the ConnectionImpl.

Use case: The ConnectionHandler sets up a timer upon finalizing a send operation, which wakes up after the heartbeat interval and calls `Connection::heartbeat(true)`. 

In the current implementation, the ConnectionImpl would just update the idle state of the connection, but not actually send a heartbeat.