### PR TITLE
Check pipe writes in linux_tcp to suppress Wunused-result in GCC

### DIFF
--- a/src/linux_tcp/pipe.h
+++ b/src/linux_tcp/pipe.h
@@ -75,14 +75,15 @@ public:
     
     /**
      *  Notify the pipe, so that the other thread wakes up
+     *  @return bool success/failure (errno is set on failure)
      */
-    void notify()
+    bool notify()
     {
         // one byte to send
         char byte = 0;
         
         // send one byte over the pipe - this will wake up the other thread
-        write(_fds[1], &byte, 1);
+        return write(_fds[1], &byte, 1) == 1;
     }
 };
 

--- a/src/linux_tcp/tcpresolver.h
+++ b/src/linux_tcp/tcpresolver.h
@@ -138,7 +138,10 @@ private:
         }
             
         // notify the master thread by sending a byte over the pipe
-        _pipe.notify();
+        if (!_pipe.notify())
+        {
+            _error = strerror(errno);
+        }
     }
 
 public:


### PR DESCRIPTION
Fixing issue when compiling with Wunused-result enabled in GCC.