### PR TITLE
allow setup client certs before handshake

### DIFF
--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -127,6 +127,12 @@ private:
         _handler->onConnected(this);
     }
 
+    virtual void onSetupSecurity(TcpState *state, SSL *ssl) override
+    {
+        // pass on to user-space
+        _handler->onSetupSecurity(this, ssl);
+    }
+
     /**
      *  Method that is called when the connection is secured
      *  @param  state

--- a/include/amqpcpp/linux_tcp/tcphandler.h
+++ b/include/amqpcpp/linux_tcp/tcphandler.h
@@ -60,6 +60,22 @@ public:
     }
 
     /**
+     *  Method that is called after a TCP connection has been set up but before
+     *  initiating TLS handshake. This method allows you to own certificates chain
+     *  and private key to perform TLS authentication
+     *  properties, and to break up the connection if you find it not secure enough.
+     *  @param  connection      The connection for which TLS was just started
+     *  @param  ssl             Pointer to the SSL structure that can be inspected
+     *  @return bool            True to proceed / accept the connection, false to break up
+     */
+    virtual void onSetupSecurity(TcpConnection *connection, SSL *ssl)
+    {
+        // make sure compilers dont complain about unused parameters
+        (void) connection;
+        (void) ssl;
+    }
+
+    /**
      *  Method that is called after a TCP connection has been set up and the initial 
      *  TLS handshake is finished too, but right before the AMQP login handshake is
      *  going to take place and the first data is going to be sent over the connection. 

--- a/include/amqpcpp/linux_tcp/tcpparent.h
+++ b/include/amqpcpp/linux_tcp/tcpparent.h
@@ -48,6 +48,12 @@ public:
     virtual void onConnected(TcpState *state) = 0;
 
     /**
+     *  Method that is called before performing SSL handshake
+     *  @param  state
+     */
+    virtual void onSetupSecurity(TcpState *state, SSL *ssl) = 0;
+
+    /**
      *  Method that is called when the connection is secured
      *  @param  state
      *  @param  ssl

--- a/src/linux_tcp/sslhandshake.h
+++ b/src/linux_tcp/sslhandshake.h
@@ -24,7 +24,7 @@
 /**
  *  Set up namespace
  */
-namespace AMQP { 
+namespace AMQP {
 
 /**
  *  Class definition
@@ -118,13 +118,15 @@ public:
     {
         // we will be using the ssl context as a client
         OpenSSL::SSL_set_connect_state(_ssl);
-        
+
+        _parent->onSetupSecurity(this, _ssl);
+
         // associate domain name with the connection
         OpenSSL::SSL_ctrl(_ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, (void *)hostname.data());
         
         // associate the ssl context with the socket filedescriptor
         if (OpenSSL::SSL_set_fd(_ssl, _socket) == 0) throw std::runtime_error("failed to associate filedescriptor with ssl socket");
-        
+
         // we are going to wait until the socket becomes writable before we start the handshake
         _parent->onIdle(this, _socket, writable);
     }
@@ -161,10 +163,10 @@ public:
         
         // if the connection succeeds, we can move to the ssl-connected state
         if (result == 1) return nextstate(monitor);
-        
+
         // error was returned, so we must investigate what is going on
         auto error = OpenSSL::SSL_get_error(_ssl, result);
-        
+
         // check the error
         switch (error) {
         case SSL_ERROR_WANT_READ:   return proceed(readable);


### PR DESCRIPTION
Allow implementations to set up client certificates before handshake

for example
```
void ctrl::onSetupSecurity(AMQP::TcpConnection *connection, SSL *ssl) {
	ERR_clear_error();

	unsigned long err;
	int ret = SSL_use_certificate_chain_file(ssl, "ca-chain.cert.pem");
	if (ret != 1) {
		std::string error("openssl: error loading ca-chain from[");
		SSL_get_error(ssl, ret);
		if ((err = ERR_get_error())) {
			error += std::string(ERR_reason_error_string(err));
		}

		throw std::runtime_error(error);
	}

	ERR_clear_error();
	ret = SSL_use_PrivateKey_file(ssl, "private.key.pem", SSL_FILETYPE_PEM);
	if (ret != 1) {
		std::string error("openssl: error loading private key from[");
		SSL_get_error(ssl, ret);
		if ((err = ERR_get_error())) {
			error += std::string(ERR_reason_error_string(err));
		}
		throw std::runtime_error(error);
	}

	SSL_set_verify(ssl, SSL_VERIFY_NONE, nullptr);
}
```