### PR TITLE
fix access to free'd memory in case of errors

### DIFF
--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -846,6 +846,7 @@ void ChannelImpl::reportError(const char *message, bool notifyhandler)
     // the connection no longer has to know that this channel exists,
     // because the channel ID is no longer in use
     if (_connection) _connection->remove(this);
+    _connection = nullptr;
 }
 
 /**


### PR DESCRIPTION
I notices a invalid memory access with valgrind which was caused by the following sequence

- An error occurs
- The channel calls `_connection->remove`, unregistering from the `_channels` of it's connections
- The `ConnectionImpl` gets destructed but does not detach because the `_channels` is empty
- The `ChannelImpl` gets destructed, still has a `_connection`, attempting to `_connection->remove` on the destructed `_connection`.

The suggested solution is to reset the `_connection` in the error handler. One could also just call `detach`.