### PR TITLE
Field: remove uncallable conversion operator for Array and Table

### DIFF
--- a/include/amqpcpp/array.h
+++ b/include/amqpcpp/array.h
@@ -218,25 +218,6 @@ public:
         // postfix
         stream << ")";
     }
-
-    /**
-     *  Cast to array.
-     *
-     *  @note:  This function may look silly and unnecessary. We are, after all, already
-     *          an array. The whole reason we still have this function is that it is virtual
-     *          and if we do not declare a cast to array on a pointer to base (i.e. Field)
-     *          will return an empty field instead of the expected array.
-     *
-     *          Yes, clang gets this wrong and gives incorrect warnings here. See
-     *          https://llvm.org/bugs/show_bug.cgi?id=28263 for more information
-     *
-     *  @return Ourselves
-     */
-    virtual operator const Array& () const override
-    {
-        // this already is an array, so no cast is necessary
-        return *this;
-    }
 };
 
 /**

--- a/include/amqpcpp/table.h
+++ b/include/amqpcpp/table.h
@@ -252,25 +252,6 @@ public:
         // postfix
         stream << ")";
     }
-
-    /**
-     *  Cast to table.
-     *
-     *  @note:  This function may look silly and unnecessary. We are, after all, already
-     *          a table. The whole reason we still have this function is that it is virtual
-     *          and if we do not declare a cast to table on a pointer to base (i.e. Field)
-     *          will return an empty field instead of the expected table.
-     *
-     *          Yes, clang gets this wrong and gives incorrect warnings here. See
-     *          https://llvm.org/bugs/show_bug.cgi?id=28263 for more information
-     *
-     *  @return Ourselves
-     */
-    virtual operator const Table& () const override
-    {
-        // this already is a table, so no cast is necessary
-        return *this;
-    }
 };
 
 /**

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -67,7 +67,12 @@ Field::operator const Array& () const
     // static empty array
     static Array empty;
     
-    // return it
+    // if this is an Array then return it
+    if (auto dcp = dynamic_cast<const Array*>(this)) {
+        return *dcp;
+    }
+    
+    // otherwise reference an empty Array
     return empty;
 }
 
@@ -80,7 +85,12 @@ Field::operator const Table& () const
     // static empty table
     static Table empty;
     
-    // return it
+    // if this is a Table then return it
+    if (auto dcp = dynamic_cast<const Table*>(this)) {
+        return *dcp;
+    }
+    
+    // otherwise reference an empty Table
     return empty;
 }
 


### PR DESCRIPTION
Like clang gcc9 diagnoses the declaration when -Wclass-conversion is
enabled.  This prevents building applications that use AMQP-CPP with
-Werror.

Replace the uncallable overload with a test in the base class method
that returns the proper value when the source value is the destination
type.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>