### PR TITLE
linux_tcp/poll: fix undefined behavior in select

### DIFF
--- a/src/linux_tcp/poll.h
+++ b/src/linux_tcp/poll.h
@@ -106,8 +106,11 @@ public:
      */
     bool active(bool block)
     {
+        // accommodate restrict qualifier on fd_set params
+        fd_set set2 = _set;
+
         // wait for the socket
-        if (block) return select(_socket + 1, &_set, &_set, nullptr, nullptr) > 0;
+        if (block) return select(_socket + 1, &_set, &set2, nullptr, nullptr) > 0;
 
         // we do not want to block, so we use a small timeout
         struct timeval timeout;
@@ -116,7 +119,7 @@ public:
         timeout.tv_sec = timeout.tv_usec = 0;
         
         // no timeout at all
-        return select(_socket + 1, &_set, &_set, nullptr, &timeout) > 0;
+        return select(_socket + 1, &_set, &set2, nullptr, &timeout) > 0;
     }
 };
 
@@ -124,4 +127,3 @@ public:
  *  End of namespace
  */
 }
-


### PR DESCRIPTION
The select(2) system call on Linux now includes the restrict qualifier
on the fd_set pointers passed in, causing a diagnostic in gcc9 for the
call blocking for both read and write.  Pass a pointer to a temporary
copy of the set when two references are required.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>