### PR TITLE
ConnectionImpl::remove maybe called recursively

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -607,29 +607,7 @@ public:
      *
      *  @return bool
      */
-    bool reportClosed()
-    {
-        // change state
-        _state = state_closed;
-
-        // create a monitor, because the callbacks could destruct the current object
-        Monitor monitor(this);
-
-        // and pass on to the reportSuccess() method which will call the
-        // appropriate deferred object to report the successful operation
-        bool result = reportSuccess();
-
-        // leap out if object no longer exists
-        if (!monitor.valid()) return result;
-
-        // all later deferred objects should report an error, because it
-        // was not possible to complete the instruction as the channel is
-        // now closed (but the channel onError does not have to run)
-        reportError("Channel has been closed", false);
-
-        // done
-        return result;
-    }
+    bool reportClosed();
 
     /**
      *  Report success

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -789,6 +789,7 @@ void ChannelImpl::flush()
  */
 void ChannelImpl::reportError(const char *message, bool notifyhandler)
 {
+    auto self = shared_from_this(); //keep a strong reference
     // change state
     _state = state_closed;
     _synchronous = false;


### PR DESCRIPTION
0. Connection::fail
1. ConnectionImpl::fail
2. ChannelImpl::reportError
3. ConnectionImpl::remove(this) #
4. ConnectionImpl::_channels.erase(channel->id()); ##
5. ChannelImpl::~ChannelImpl()
6. ConnectionImpl::remove(this) # 
7. ConnectionImpl::_channels.erase(channel->id());## crash