### PR TITLE
Adds channel callbacks checking

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -218,7 +218,7 @@ public:
         _readyCallback = callback;
 
         // direct call if channel is already ready
-        if (_state == state_ready) callback();
+        if (_state == state_ready && callback) callback();
     }
 
     /**

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -73,7 +73,10 @@ void ChannelImpl::onError(const ErrorCallback &callback)
 
     // if the channel is usable, all is ok
     if (usable()) return;
-    
+
+    // validity check
+    if (!callback) return;
+
     // is the channel closing down?
     if (_state == state_closing) return callback("Channel is closing down");
 


### PR DESCRIPTION
When I tried to reset the callbacks with nullptr, bad_function_call was thrown.