### PR TITLE
Checked destruction of moved channel

### DIFF
--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -70,7 +70,7 @@ public:
      */
     bool isValid() const
     {
-        return _implementation;
+        return static_cast<bool>(_implementation);
     }
 
     /**

--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -22,7 +22,7 @@ class Channel
 private:
     /**
      *  The implementation for the channel
-     *  @var    std::unique_ptr<ChannelImpl>
+     *  @var    std::shared_ptr<ChannelImpl>
      */
     std::shared_ptr<ChannelImpl> _implementation;
 
@@ -50,7 +50,7 @@ public:
      *  But movement _is_ allowed
      *  @param  channel
      */
-    Channel(Channel &&channel) : _implementation(std::move(channel._implementation)) {}
+    Channel(Channel &&channel) = default;
 
     /**
      *  Destructor
@@ -58,7 +58,19 @@ public:
     virtual ~Channel() 
     {
         // close the channel (this will eventually destruct the channel)
-        _implementation->close();
+        if (_implementation)
+            _implementation->close();
+    }
+
+    /**
+     *  Returns validity of the channel
+     *
+     *  Checks if the _implementation is valid or was moved.
+     *  @return bool
+     */
+    bool isValid() const
+    {
+        return _implementation;
     }
 
     /**


### PR DESCRIPTION
Added check for _implementation validity in the destructor. After move, the ptr becomes invalid yet close() was still called on it in the destructor. IsValid function was added so the children can also check if the channel was moved or not.
