### PR TITLE
Fixed issue where timeout triggered an invald error

### DIFF
--- a/include/amqpcpp/connection.h
+++ b/include/amqpcpp/connection.h
@@ -197,12 +197,21 @@ public:
     }
     
     /**
-     *  Is the connection ready to accept instructions / has passed the login handshake?
+     *  Is the connection ready to accept instructions / has passed the login handshake and not closed?
      *  @return bool
      */
     bool ready() const
     {
         return _implementation.ready();
+    }
+
+    /**
+     *  Is (or was) the connection initialized
+     *  @return bool
+     */
+    bool initialized() const
+    {
+        return _implementation.initialized();
     }
     
     /**

--- a/include/amqpcpp/connectionimpl.h
+++ b/include/amqpcpp/connectionimpl.h
@@ -219,13 +219,24 @@ public:
 
     /**
      *  Are we fully connected and ready for instructions? This is true after the initial
-     *  protocol and login handshake were completed.
+     *  protocol and login handshake were completed and the connection is not closed.
      *  @return bool
      */
     bool ready() const
     {
         // state must be connected
         return _state == state_connected;
+    }
+
+    /**
+     *  Is (or was) the connection initialized
+     *  @return bool
+     */
+    bool initialized() const
+    {
+        // We are initalized if we have passed the initialized state. So we are in
+        // a connected, closing, or closed state.
+        return _state == state_connected || _state == state_closing || _state == state_closed;
     }
 
     /**

--- a/include/amqpcpp/libev.h
+++ b/include/amqpcpp/libev.h
@@ -234,7 +234,7 @@ private:
             
             // timer is no longer active, so the refcounter in the loop is restored
             ev_ref(_loop);
-            
+
             // if the onNegotiate method was not yet called, and no heartbeat timeout was negotiated
             if (_timeout == 0)
             {
@@ -243,10 +243,10 @@ private:
                 // in either case we're no longer going to run further timers.
                 _next = _expire = 0.0;
                 
-                // if we have a valid connection, user-space must have overridden the onNegotiate
+                // if we have an initialized connection, user-space must have overridden the onNegotiate
                 // method, so we keep using the connection
-                if (_connection->ready()) return;
-                
+                if (_connection->initialized()) return;
+
                 // this is a connection timeout, close the connection from our side too
                 return (void)_connection->close(true);
             }

--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -57,7 +57,7 @@ private:
      *  @friend
      */
     friend TcpChannel;
-    
+
 
     /**
      *  Method that is called when the RabbitMQ server and your client application  
@@ -237,12 +237,23 @@ public:
     bool close(bool immediate = false);
     
     /**
-     *  Is the connection connected, meaning: it has passed the login handshake?
+     *  Is the connection connected, meaning: it has passed the login handshake
+     *  and isn't closed yet?
      *  @return bool
      */
     bool ready() const
     {
         return _connection.ready();
+    }
+
+    /**
+     *  Is the connection initialized, meaning: it has passed the login handshake?
+     *  It may be closing or closed
+     *  @return bool
+     */
+    bool initialized() const
+    {
+        return _connection.initialized();
     }
     
     /**


### PR DESCRIPTION
If the negotiate is overwritten by the handler and the connection was closed but still a timeout was triggered you always got the error "connection prematurely closed by client". This is incorrect behavior.