### PR TITLE
Added Void field type

### DIFF
--- a/include/amqpcpp.h
+++ b/include/amqpcpp.h
@@ -55,6 +55,7 @@
 #include "amqpcpp/fieldproxy.h"
 #include "amqpcpp/table.h"
 #include "amqpcpp/array.h"
+#include "amqpcpp/voidfield.h"
 
 // envelope for publishing and consuming
 #include "amqpcpp/metadata.h"

--- a/include/amqpcpp/field.h
+++ b/include/amqpcpp/field.h
@@ -112,6 +112,7 @@ public:
     virtual bool isTable()   const { return false; }
     virtual bool isBoolean() const { return false; }
     virtual bool isString()  const { return false; }
+    virtual bool isVoid()    const { return false; }
 };
 
 /**

--- a/include/amqpcpp/fieldproxy.h
+++ b/include/amqpcpp/fieldproxy.h
@@ -19,6 +19,7 @@
 #include "booleanset.h"
 #include "decimalfield.h"
 #include "numericfield.h"
+#include "voidfield.h"
 
 /**
  *  Set up namespace

--- a/include/amqpcpp/table.h
+++ b/include/amqpcpp/table.h
@@ -138,6 +138,7 @@ public:
     Table &set(const std::string &name, int64_t value) { return set(name, LongLong(value)); }
     Table &set(const std::string &name, const std::string &value) { return set(name, LongString(value)); }
     Table &set(const std::string &name, const char *value) { return set(name, LongString(std::string(value))); }
+    Table &set(const std::string &name, nullptr_t) { return set(name, VoidField()); }
 
     /**
      *  Is a certain field set in the table

--- a/include/amqpcpp/voidfield.h
+++ b/include/amqpcpp/voidfield.h
@@ -60,16 +60,6 @@ public:
     }
 
     /**
-     *  We are an integer field
-     *
-     *  @return true, because we are an integer
-     */
-    bool isInteger() const override
-    {
-        return false;
-    }
-
-    /**
      *  Get the size this field will take when
      *  encoded in the AMQP wire-frame format
      *  @return size_t

--- a/include/amqpcpp/voidfield.h
+++ b/include/amqpcpp/voidfield.h
@@ -1,0 +1,124 @@
+/**
+ *  Void field type for AMQP
+ *
+ *  @copyright 
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Dependencies
+ */
+#include <memory>
+#include "receivedframe.h"
+#include "outbuffer.h"
+#include "field.h"
+
+/**
+ *  Set up namespace
+ */
+namespace AMQP
+{
+class VoidField : public Field
+{
+private:
+    /**
+     *  Field have no value
+     */
+    
+public:
+    /**
+     *  Default constructor
+     */
+    VoidField() {}
+
+    /**
+     *  Parse based on incoming buffer
+     *  @param  frame
+     */
+    VoidField(ReceivedFrame &frame)
+    {
+
+    }
+
+    /**
+ *  Destructor
+ */
+    virtual ~VoidField() {}
+
+    /**
+     *  Create a new instance of this object
+     *  @return Field*
+     */
+    virtual std::shared_ptr<Field> clone() const override
+    {
+        // create a new copy of ourselves and return it
+        return std::make_shared<VoidField>();
+    }
+
+    /**
+     *  We are an integer field
+     *
+     *  @return true, because we are an integer
+     */
+    bool isInteger() const override
+    {
+        return false;
+    }
+
+    /**
+     *  Get the size this field will take when
+     *  encoded in the AMQP wire-frame format
+     *  @return size_t
+     */
+    virtual size_t size() const override
+    {
+        // numeric types have no extra storage requirements
+        return 0;
+    }
+
+    /**
+     *  Write encoded payload to the given buffer.
+     *  @param  buffer      OutBuffer to write to
+     */
+    virtual void fill(OutBuffer &buffer) const override
+    {
+    }
+
+    /**
+     *  Get the type ID that is used to identify this type of
+     *  field in a field table
+     */
+    virtual char typeID() const override
+    {
+        return 'V';
+    }
+
+    /**
+     *  Output the object to a stream
+     *  @param std::ostream
+     */
+    virtual void output(std::ostream &stream) const override
+    {
+        // show
+        stream << "void()";
+    }
+
+    /**
+     *  We are an void field
+     *
+     *  @return true, because we are an void
+     */
+    bool isVoid() const override
+    {
+        return true;
+    }
+};
+
+/**
+ *  end namespace
+ */
+}

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -41,6 +41,7 @@ Field *Field::decode(ReceivedFrame &frame)
         case 'A':   return new Array(frame);
         case 'T':   return new Timestamp(frame);
         case 'F':   return new Table(frame);
+        case 'V':   return new VoidField(frame);
         default:    return nullptr;
     }
 }

--- a/src/includes.h
+++ b/src/includes.h
@@ -53,10 +53,10 @@
 #include "amqpcpp/decimalfield.h"
 #include "amqpcpp/stringfield.h"
 #include "amqpcpp/booleanset.h"
+#include "amqpcpp/voidfield.h"
 #include "amqpcpp/fieldproxy.h"
 #include "amqpcpp/table.h"
 #include "amqpcpp/array.h"
-#include "amqpcpp/voidfield.h"
 
 // envelope for publishing and consuming
 #include "amqpcpp/metadata.h"

--- a/src/includes.h
+++ b/src/includes.h
@@ -56,6 +56,7 @@
 #include "amqpcpp/fieldproxy.h"
 #include "amqpcpp/table.h"
 #include "amqpcpp/array.h"
+#include "amqpcpp/voidfield.h"
 
 // envelope for publishing and consuming
 #include "amqpcpp/metadata.h"


### PR DESCRIPTION
Fixes: #344 

I've added hot-fix and I not sure sure if it is follows your code conventions.
At now there no exceptions and I could list keys with void values nested or not.
File `voidfield.h ` is copy-paste based from `numericfield.h`