### PR TITLE
A connection to a non-existing IP (where the connect hangs) causes hanging on destruction

### DIFF
--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -141,6 +141,12 @@ bool TcpConnection::close(bool immediate)
     // stop if object was destructed
     if (!monitor.valid()) return true;
     
+    // tell the handler that no further events will be fired
+    _handler->onDetached(this);
+    
+    // stop if object was destructed
+    if (!monitor.valid()) return true;
+      
     // change the state
     _state.reset(new TcpClosed(this));
     


### PR DESCRIPTION
Because the thread is still waiting to join. This PR monitors the connect socket asynchronously using select, and also a separate pipe that can notify the thread to stop immediately. Additionally, it shortens the timeout.

Also, onDetached is now properly called after a close(true) is called on a connection (given that it still exists).