### PR TITLE
Fix merge problem of #345

### DIFF
--- a/include/amqpcpp/voidfield.h
+++ b/include/amqpcpp/voidfield.h
@@ -13,7 +13,7 @@
  *  Dependencies
  */
 #include <memory>
-#include "receivedframe.h"
+#include "inbuffer.h"
 #include "outbuffer.h"
 #include "field.h"
 
@@ -39,7 +39,7 @@ public:
      *  Parse based on incoming buffer
      *  @param  frame
      */
-    VoidField(ReceivedFrame &frame)
+    VoidField(InBuffer &frame)
     {
 
     }


### PR DESCRIPTION
I've found that within commits starting from July changed `ReceivedFrame` class into `InBuffer`.
So my previous #345 pull request became incompatible.

This short commit fixes problem. Also I've tested it with Python's Celery and it works like with #345.