### PR TITLE
<boost/bind.hpp> is deprecated, using <boost/bind/bind.hpp>.

### DIFF
--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -30,7 +30,7 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 
 #include "amqpcpp/linux_tcp.h"


### PR DESCRIPTION
I forgot about boost/bind.hpp. It is deprecated too. When build with BOOST_ASIO_NO_DEPRECATED got this warning:
`/usr/include/boost/bind.hpp:41:1: note: #pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.`