### PR TITLE
select only supports upto fd 1024, which can cause stack smashing if using higher ones

### DIFF
--- a/src/linux_tcp/sslconnected.h
+++ b/src/linux_tcp/sslconnected.h
@@ -220,8 +220,8 @@ private:
         // object to poll a socket
         Poll poll(_socket);
         
-        // wait until socket is readable, but do not block
-        return poll.readable(false);
+        // check if socket is readable
+        return poll.readable();
     }
 
     /**
@@ -233,8 +233,8 @@ private:
         // object to poll a socket
         Poll poll(_socket);
         
-        // wait until socket is writable, but do not block
-        return poll.writable(false);
+        // check if socket is writable
+        return poll.writable();
     }
     
     /**


### PR DESCRIPTION
`select` potentially only supports monitoring file descriptors < 1024. See https://man7.org/linux/man-pages/man2/select.2.html

With the relevant portion under BUGS:

```
POSIX allows an implementation to define an upper limit, advertised
       via the constant FD_SETSIZE, on the range of file descriptors that
       can be specified in a file descriptor set.  The Linux kernel imposes
       no fixed limit, but the glibc implementation makes fd_set a fixed-
       size type, with FD_SETSIZE defined as 1024, and the FD_*() macros
       operating according to that limit.  To monitor file descriptors
       greater than 1023, use poll(2) or epoll(7) instead.
```

This causes stack smashing because it's implemented as a bit array, and it clobbers the stack if higher FDs are used since it will write past the end.