### PR TITLE
Add option to select an IP randomly

### DIFF
--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -192,8 +192,9 @@ public:
      *  Constructor
      *  @param  handler         User implemented handler object
      *  @param  hostname        The address to connect to
+     *  @param  random          Randomly select one of the IP addresses that belong to the hostname
      */
-    TcpConnection(TcpHandler *handler, const Address &address);
+    TcpConnection(TcpHandler *handler, const Address &address, bool random = false);
     
     /**
      *  No copying

--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -192,9 +192,8 @@ public:
      *  Constructor
      *  @param  handler         User implemented handler object
      *  @param  hostname        The address to connect to
-     *  @param  random          Randomly select one of the IP addresses that belong to the hostname
      */
-    TcpConnection(TcpHandler *handler, const Address &address, bool random = false);
+    TcpConnection(TcpHandler *handler, const Address &address);
     
     /**
      *  No copying

--- a/src/linux_tcp/address2str.h
+++ b/src/linux_tcp/address2str.h
@@ -1,0 +1,108 @@
+/**
+ *  Address2Str.h
+ * 
+ *  Helper class to get a stringed version of an address obtained from get_addrinfo
+ *  
+ *  @author Aljar Meesters <aljar.meesters@copernica.com
+ *  @copyright 2020 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Dependencies
+ */
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+/**
+ *  Opening namespace
+ */
+namespace AMQP {
+
+/**
+ *  class implemenation
+ */
+class Address2str
+{
+private:
+    /**
+     *  The address as string
+     */
+    char *_buffer = nullptr;
+
+public:
+    /**
+     *  Constructor
+     *  @param struct addrinfo *
+     */
+    Address2str(struct addrinfo *info)
+    {
+        // Switch on family
+        switch(info->ai_family)
+        {
+            // If we are ip4
+            case AF_INET: 
+            {
+                // ugly cast
+                struct sockaddr_in *addr_in = (struct sockaddr_in *)(info->ai_addr);
+                
+                // create the buffer
+                _buffer = new char[INET_ADDRSTRLEN];
+                
+                // get the info in our buffer
+                inet_ntop(AF_INET, &(addr_in->sin_addr), _buffer, INET_ADDRSTRLEN);
+                
+                // done
+                break;
+            }
+
+            // if we are ipv6
+            case AF_INET6:
+            {
+                // ugly cast
+                struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)(info->ai_addr);
+
+                // crate buffer
+                _buffer = new char[INET6_ADDRSTRLEN];
+
+                // get the info in our buffer
+                inet_ntop(AF_INET6, &(addr_in6->sin6_addr), _buffer, INET6_ADDRSTRLEN);
+                
+                // done
+                break;
+            }
+            default:
+                // If it is not ipv4 or ipv6 we don't set it.
+                break;
+        }
+    }
+
+    /**
+     *  Destruction
+     */
+    virtual ~Address2str()
+    {
+        // if we have a buffer, we should free it.
+        if (_buffer) delete[](_buffer);
+    }
+
+    /**
+     *  get the char
+     *  @return char*
+     */
+    const char *toChar() const
+    {
+        // expose the buffer.
+        return _buffer;
+    }
+};
+
+
+/**
+ * ending of namespace
+ */
+}

--- a/src/linux_tcp/addressinfo.h
+++ b/src/linux_tcp/addressinfo.h
@@ -10,7 +10,7 @@
 /**
  *  Dependencies
  */
-#include <sys/time.h>
+#include <random>
 
 /**
  *  Include guard
@@ -76,17 +76,14 @@ public:
         // which may break loadbalancing..
         if (randomOrder)
         {
-            // We need to seed the random number generator. Normally time is taken
-            // for this. Since we want to have randomness within a second we use
-            // more precision via timeval
-            struct timeval time; 
-            gettimeofday(&time, nullptr);
+            // create a random device for the seed of the random number generator
+            std::random_device rd;
 
-            // We seed with the precision of miliseconds. 
-            srand((time.tv_sec * 1000) + (time.tv_usec / 1000));  
+            // Create the generator
+            std::mt19937 gen(rd());
 
-            // shuffle the vector.    
-            std::random_shuffle(_v.begin(), _v.end());
+            // shuffle the vector.
+            std::shuffle(_v.begin(), _v.end(), gen);
         }
     }
 

--- a/src/linux_tcp/connectionorder.h
+++ b/src/linux_tcp/connectionorder.h
@@ -1,0 +1,73 @@
+/**
+ *  ConnectionOrder.h
+ *  
+ *  Class that give info on how we want to sellect the connection from a list of IPs
+ * 
+ *  @author Aljar Meesters <aljar.meesters@copernica.com>
+ *  @copyright 2020 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Setup namespace
+ */
+namespace AMQP
+{
+
+/**
+ *  Class implementation
+ */
+class ConnectionOrder
+{
+public:
+    /**
+     *  Enum class holding the orders we support
+     *  - standard:   what is used by getaddrinfo, which is proximity based
+     *  - reverse:    reverse the standard order
+     *  - random:     random order
+     *  - ascending:  try the smallest IP address first
+     *  - descending: try the largest IP address first
+     *  @var enum Order
+     */
+    enum class Order { standard, reverse, random, ascending, descending};
+
+private: 
+    /**
+     *  The order for the connection
+     *  @var Order
+     */
+    Order _order;
+
+public:
+    /**
+     *  Constructor
+     *  @var  order
+     */
+    ConnectionOrder (const char *order) : _order(Order::standard)
+    {
+        // Set the orders based on the string
+        if (strcmp(order, "random") == 0) _order = Order::random;
+        else if (strcmp(order, "ascending") == 0 || strcmp(order, "asc") == 0) _order = Order::ascending;
+        else if (strcmp(order, "descending") == 0 || strcmp(order, "desc") == 0 ) _order = Order::descending;
+
+        // If we don't ave a match we fall back to standard, which was set as default
+    }
+
+    /**
+     *  Get the order
+     *  @return Order
+     */
+    Order order()
+    {
+        return _order;
+    }
+};
+
+/**
+ *  End of namespace
+ */
+}

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -23,11 +23,10 @@ namespace AMQP {
  *  Constructor
  *  @param  handler         User implemented handler object
  *  @param  hostname        The address to connect to
- *  @param  random          Randomly select one of the IP addresses that belong to the hostname
  */
-TcpConnection::TcpConnection(TcpHandler *handler, const Address &address, bool random) :
+TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
     _handler(handler),
-    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), random)),
+    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), address.option("randomConnect", false))),
     _connection(this, address.login(), address.vhost()) 
 {
     // tell the handler

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -26,7 +26,7 @@ namespace AMQP {
  */
 TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
     _handler(handler),
-    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), address.option("randomConnect", false))),
+    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), ConnectionOrder(address.option("connectionOrder")).order())),
     _connection(this, address.login(), address.vhost()) 
 {
     // tell the handler

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -23,10 +23,11 @@ namespace AMQP {
  *  Constructor
  *  @param  handler         User implemented handler object
  *  @param  hostname        The address to connect to
+ *  @param  random          Randomly select one of the IP addresses that belong to the hostname
  */
-TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
+TcpConnection::TcpConnection(TcpHandler *handler, const Address &address, bool random) :
     _handler(handler),
-    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5))),
+    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), random)),
     _connection(this, address.login(), address.vhost()) 
 {
     // tell the handler
@@ -286,4 +287,3 @@ void TcpConnection::onLost(TcpState *state)
  *  End of namespace
  */
 }
-

--- a/src/linux_tcp/tcpresolver.h
+++ b/src/linux_tcp/tcpresolver.h
@@ -86,10 +86,10 @@ private:
     std::thread _thread;
 
     /**
-     *  Do we want to have random ordering
+     *  How should the addresses be ordered when we want to connect
      *  @var bool
      */
-    bool _random;
+    ConnectionOrder::Order _order;
 
 
     /**
@@ -104,7 +104,7 @@ private:
             if (_secure && !OpenSSL::valid()) throw std::runtime_error("Secure connection cannot be established: libssl.so cannot be loaded");
             
             // get address info
-            AddressInfo addresses(_hostname.data(), _port, _random);
+            AddressInfo addresses(_hostname.data(), _port, _order);
     
             // the pollfd structure, needed for poll()
             pollfd fd;
@@ -194,15 +194,15 @@ public:
      *  @param  portnumber  The portnumber for the lookup
      *  @param  secure      Do we need a secure tls connection when ready?
      *  @param  timeout     timeout per connection attempt
-     *  @param  random      Do we want to have random oredering of the address of the host to connect to
+     *  @param  order       How should we oreder the addresses of the host to connect to
      */
-    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout, bool random) : 
+    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout, ConnectionOrder::Order order) : 
         TcpExtState(parent), 
         _hostname(std::move(hostname)),
         _secure(secure),
         _port(port),
         _timeout(timeout),
-        _random(random)
+        _order(order)
     {
         // tell the event loop to monitor the filedescriptor of the pipe
         parent->onIdle(this, _pipe.in(), readable);

--- a/src/linux_tcp/tcpresolver.h
+++ b/src/linux_tcp/tcpresolver.h
@@ -85,6 +85,12 @@ private:
      */
     std::thread _thread;
 
+    /**
+     *  Do we want to have random ordering
+     *  @var bool
+     */
+    bool _random;
+
 
     /**
      *  Run the thread
@@ -98,7 +104,7 @@ private:
             if (_secure && !OpenSSL::valid()) throw std::runtime_error("Secure connection cannot be established: libssl.so cannot be loaded");
             
             // get address info
-            AddressInfo addresses(_hostname.data(), _port);
+            AddressInfo addresses(_hostname.data(), _port, _random);
     
             // the pollfd structure, needed for poll()
             pollfd fd;
@@ -188,13 +194,15 @@ public:
      *  @param  portnumber  The portnumber for the lookup
      *  @param  secure      Do we need a secure tls connection when ready?
      *  @param  timeout     timeout per connection attempt
+     *  @param  random      Do we want to have random oredering of the address of the host to connect to
      */
-    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout) : 
+    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout, bool random) : 
         TcpExtState(parent), 
         _hostname(std::move(hostname)),
         _secure(secure),
         _port(port),
-        _timeout(timeout)
+        _timeout(timeout),
+        _random(random)
     {
         // tell the event loop to monitor the filedescriptor of the pipe
         parent->onIdle(this, _pipe.in(), readable);


### PR DESCRIPTION
The default behavior of getaddrinfo is to sort the IPs based on proximity. This request add the option to order the IPs randomly for a connection, so loads are distributed more evenly.