### PR TITLE
Fixed the segfault which can happen after address.option("connectionOrder") return nullptr

### DIFF
--- a/src/linux_tcp/connectionorder.h
+++ b/src/linux_tcp/connectionorder.h
@@ -50,7 +50,8 @@ public:
     ConnectionOrder(const char *order) : _order(Order::standard)
     {
         // Set the orders based on the string
-        if      (strcmp(order, "random") == 0) _order = Order::random;
+        if      (order == nullptr) {} // first check if the order is not null
+        else if (strcmp(order, "random") == 0) _order = Order::random;
         else if (strcmp(order, "ascending") == 0 || strcmp(order, "asc") == 0) _order = Order::ascending;
         else if (strcmp(order, "descending") == 0 || strcmp(order, "desc") == 0 ) _order = Order::descending;
     }


### PR DESCRIPTION
Added check if the connectionOrder receives nullptr and not a valid string. This can be a case if address.option("connectionOrder") returns nullptr.