### PR TITLE
SslHandshake set default verify path

### DIFF
--- a/src/linux_tcp/openssl.cpp
+++ b/src/linux_tcp/openssl.cpp
@@ -72,6 +72,25 @@ const SSL_METHOD *TLS_client_method()
 }
 
 /**
+ *  Get the SSL_METHOD for incoming connections
+ *  @return SSL_METHOD *
+ */
+const SSL_METHOD *TLS_server_method()
+{
+    // create a function that loads the method
+    static Function<decltype(TLS_server_method)> func(handle, "TLS_server_method");
+    
+    // call the openssl function
+    if (func) return func();
+    
+    // older openssl libraries do not have this function, so we try to load an other function
+    static Function<decltype(TLS_server_method)> old(handle, "SSLv23_server_method");
+    
+    // call the old one
+    return old();
+}
+
+/**
  *  Create new SSL context
  *  @param  method  SSL_METHOD can be of the following types: TLS_method(), TLS_server_method(), TLS_client_method()
  *  @return         pointer to object   
@@ -325,6 +344,20 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
     
     // call the openssl function
     return func(ctx, cmd, larg, parg);
+}
+
+/**
+ *  Specify that the default location from which CA certificates are loaded
+ *  should be used.
+ *  @param  ctx
+ */
+int SSL_CTX_set_default_verify_paths(SSL_CTX *ctx)
+{
+    // the actual function
+    static Function<decltype(::SSL_CTX_set_default_verify_paths)> func(handle, "SSL_CTX_set_default_verify_paths");
+
+    // call actual function
+    return func(ctx);
 }
 
 /**

--- a/src/linux_tcp/openssl.cpp
+++ b/src/linux_tcp/openssl.cpp
@@ -72,25 +72,6 @@ const SSL_METHOD *TLS_client_method()
 }
 
 /**
- *  Get the SSL_METHOD for incoming connections
- *  @return SSL_METHOD *
- */
-const SSL_METHOD *TLS_server_method()
-{
-    // create a function that loads the method
-    static Function<decltype(TLS_server_method)> func(handle, "TLS_server_method");
-    
-    // call the openssl function
-    if (func) return func();
-    
-    // older openssl libraries do not have this function, so we try to load an other function
-    static Function<decltype(TLS_server_method)> old(handle, "SSLv23_server_method");
-    
-    // call the old one
-    return old();
-}
-
-/**
  *  Create new SSL context
  *  @param  method  SSL_METHOD can be of the following types: TLS_method(), TLS_server_method(), TLS_client_method()
  *  @return         pointer to object   

--- a/src/linux_tcp/openssl.h
+++ b/src/linux_tcp/openssl.h
@@ -35,7 +35,6 @@ bool valid();
  *  List of all wrapper methods that are in use inside AMQP-CPP
  */
 const SSL_METHOD *TLS_client_method();
-const SSL_METHOD *TLS_server_method();
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
 SSL     *SSL_new(SSL_CTX *ctx);
 int      SSL_do_handshake(SSL *ssl);

--- a/src/linux_tcp/openssl.h
+++ b/src/linux_tcp/openssl.h
@@ -35,6 +35,7 @@ bool valid();
  *  List of all wrapper methods that are in use inside AMQP-CPP
  */
 const SSL_METHOD *TLS_client_method();
+const SSL_METHOD *TLS_server_method();
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
 SSL     *SSL_new(SSL_CTX *ctx);
 int      SSL_do_handshake(SSL *ssl);
@@ -51,6 +52,7 @@ void     SSL_CTX_free(SSL_CTX *ctx);
 void     SSL_free(SSL *ssl);
 long     SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg);
 long     SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg);
+int      SSL_CTX_set_default_verify_paths(SSL_CTX *ctx);
 void     ERR_clear_error(void);
 
 /**

--- a/src/linux_tcp/sslhandshake.h
+++ b/src/linux_tcp/sslhandshake.h
@@ -33,6 +33,12 @@ class SslHandshake : public TcpExtState
 {
 private:
     /**
+     *  Ssl context
+     *  @var SslContext
+     */
+    SslContext _ctx;
+
+    /**
      *  SSL structure
      *  @var SslWrapper
      */
@@ -113,9 +119,13 @@ public:
      */
     SslHandshake(TcpExtState *state, const std::string &hostname, TcpOutBuffer &&buffer) : 
         TcpExtState(state),
-        _ssl(SslContext(OpenSSL::TLS_client_method())),
+        _ctx(OpenSSL::TLS_client_method()),
+        _ssl(_ctx),
         _out(std::move(buffer))
     {
+        // use the default directories for verifying certificates
+        OpenSSL::SSL_CTX_set_default_verify_paths(_ctx);
+
         // we will be using the ssl context as a client
         OpenSSL::SSL_set_connect_state(_ssl);
         


### PR DESCRIPTION
In linux_tcp/sslhandshake a new SSLContext is created but no verify path is set, leading to incorrect failures on certificate verification. This PR sets the default verify path for the new context.