### PR TITLE
Fix Tagger::close

### DIFF
--- a/src/tagger.cpp
+++ b/src/tagger.cpp
@@ -158,7 +158,7 @@ Deferred &Tagger::close()
     if (_close) return *_close;
 
     // create the deferred
-    _close = std::make_shared<Deferred>(_implementation->usable());
+    _close = std::make_shared<Deferred>(!_implementation->usable());
 
     // if there are open messages or there is a queue, they will still get acked and we will then forward it
     if (unacknowledged()) return *_close;


### PR DESCRIPTION
The deferred parameter indicatates if it failed, while the call in Tagger::close assumed that the parameter indicated usable. This causes that the deferred object always ended up in the onError. This is now fixed