### PR TITLE
Find and Link OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
 
 if(AMQP-CPP_LINUX_TCP)
     target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
-    # Find and link OpenSSL
+    # Find OpenSSL and provide include dirs
     find_package(OpenSSL REQUIRED)
-    target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #       ON:  Build posix handler implementation
 #       OFF: Don't build posix handler implementation
 
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
 # project name
 project(amqpcpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,4 +129,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
 
 if(AMQP-CPP_LINUX_TCP)
     target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
+    # Find and link OpenSSL
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)
 endif()


### PR DESCRIPTION
The patch allows to automatically find and link OpenSSL when `AMQP-CPP_LINUX_TCP` option is enabled.