### PR TITLE
Properly unmark synchronized channel mode

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -623,11 +623,11 @@ public:
         // if we are still in connected state we are now ready
         if (_state == state_connected) _state = state_ready;
         
-        // the last (possibly synchronous) operation was received, so we're no longer in synchronous mode
-        if (_synchronous && _queue.empty()) _synchronous = false;
-
         // inform handler
         if (_readyCallback) _readyCallback();
+
+        // the last (possibly synchronous) operation was received, so we're no longer in synchronous mode
+        if (_synchronous && _queue.empty()) _synchronous = false;
 
         // if the monitor is still valid, we flush any waiting operations 
         if (monitor.valid()) flush();


### PR DESCRIPTION
Unmarking the channel from synchronous operation in flush() might cause
multiple active synchronous operations, as flush() may be called
multiple times for a received frame with the possibility of other
frames being queued in between.

Fixes #396.