### PR TITLE
Avoid that multiple frames are sent by the channel-on-ready handler

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -617,20 +617,14 @@ public:
      */
     void reportReady()
     {
-        // callbacks could destroy us, so monitor it
-        Monitor monitor(this);
-
         // if we are still in connected state we are now ready
         if (_state == state_connected) _state = state_ready;
         
-        // the last (possibly synchronous) operation was received, so we're no longer in synchronous mode
-        if (_synchronous && _queue.empty()) _synchronous = false;
+        // send out more instructions if there is a queue
+        flush();
 
         // inform handler
         if (_readyCallback) _readyCallback();
-
-        // if the monitor is still valid, we flush any waiting operations 
-        if (monitor.valid()) flush();
     }
 
     /**

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -747,7 +747,7 @@ bool ChannelImpl::send(CopiedBuffer &&frame)
     
     // are we currently in synchronous mode or are there
     // other frames waiting for their turn to be sent?
-    if (_synchronous || !_queue.empty())
+    if (waiting())
     {
         // we need to wait until the synchronous frame has
         // been processed, so queue the frame until it was
@@ -786,7 +786,7 @@ bool ChannelImpl::send(const Frame &frame)
     
     // are we currently in synchronous mode or are there
     // other frames waiting for their turn to be sent?
-    if (_synchronous || !_queue.empty())
+    if (waiting())
     {
         // we need to wait until the synchronous frame has
         // been processed, so queue the frame until it was


### PR DESCRIPTION
This is an alternative solution for #397