### PR TITLE
Prefer make_shared over calling std::shared_ptr constructor

### DIFF
--- a/include/amqpcpp/field.h
+++ b/include/amqpcpp/field.h
@@ -40,9 +40,9 @@ protected:
      *  Decode a field by fetching a type and full field from a frame
      *  The returned field is allocated on the heap!
      *  @param  frame
-     *  @return Field*
+     *  @return std::shared_ptr<Field>
      */
-    static Field *decode(InBuffer &frame);
+    static std::shared_ptr<Field> decode(InBuffer &frame);
 
 public:
     /**

--- a/src/array.cpp
+++ b/src/array.cpp
@@ -32,7 +32,7 @@ Array::Array(InBuffer &frame)
         charsToRead -= (uint32_t)field->size();
 
         // add the additional field
-        _fields.push_back(move(field));
+        _fields.push_back(std::move(field));
     }
 }
 

--- a/src/array.cpp
+++ b/src/array.cpp
@@ -25,14 +25,14 @@ Array::Array(InBuffer &frame)
         charsToRead -= 1;
 
         // read the field type and construct the field
-        Field *field = Field::decode(frame);
+        auto field = Field::decode(frame);
         if (!field) continue;
 
         // less bytes to read
         charsToRead -= (uint32_t)field->size();
 
         // add the additional field
-        _fields.push_back(std::shared_ptr<Field>(field));
+        _fields.push_back(move(field));
     }
 }
 
@@ -46,7 +46,7 @@ Array::Array(const Array &array)
     for (auto iter = array._fields.begin(); iter != array._fields.end(); iter++)
     {
         // add to this vector
-        _fields.push_back(std::shared_ptr<Field>((*iter)->clone()));
+        _fields.push_back((*iter)->clone());
     }
 }
 
@@ -93,7 +93,7 @@ void Array::pop_back()
  */
 void Array::push_back(const Field& value)
 {
-    _fields.push_back(std::shared_ptr<Field>(value.clone()));
+    _fields.push_back(value.clone());
 }
 
 /**

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -14,9 +14,9 @@ namespace AMQP {
  *  Decode a field by fetching a type and full field from a frame
  *  The returned field is allocated on the heap!
  *  @param  frame
- *  @return Field*
+ *  @return std::shared_ptr<Field>
  */
-Field *Field::decode(InBuffer &frame)
+std::shared_ptr<Field> Field::decode(InBuffer &frame)
 {
     // get the type
     uint8_t type = frame.nextUint8();
@@ -24,24 +24,24 @@ Field *Field::decode(InBuffer &frame)
     // create field based on type
     switch (type)
     {
-        case 't':   return new BooleanSet(frame);
-        case 'b':   return new Octet(frame);
-        case 'B':   return new UOctet(frame);
-        case 'U':   return new Short(frame);
-        case 'u':   return new UShort(frame);
-        case 'I':   return new Long(frame);
-        case 'i':   return new ULong(frame);
-        case 'L':   return new LongLong(frame);
-        case 'l':   return new ULongLong(frame);
-        case 'f':   return new Float(frame);
-        case 'd':   return new Double(frame);
-        case 'D':   return new DecimalField(frame);
-        case 's':   return new ShortString(frame);
-        case 'S':   return new LongString(frame);
-        case 'A':   return new Array(frame);
-        case 'T':   return new Timestamp(frame);
-        case 'F':   return new Table(frame);
-        case 'V':   return new VoidField(frame);
+        case 't':   return std::make_shared<BooleanSet>(frame);
+        case 'b':   return std::make_shared<Octet>(frame);
+        case 'B':   return std::make_shared<UOctet>(frame);
+        case 'U':   return std::make_shared<Short>(frame);
+        case 'u':   return std::make_shared<UShort>(frame);
+        case 'I':   return std::make_shared<Long>(frame);
+        case 'i':   return std::make_shared<ULong>(frame);
+        case 'L':   return std::make_shared<LongLong>(frame);
+        case 'l':   return std::make_shared<ULongLong>(frame);
+        case 'f':   return std::make_shared<Float>(frame);
+        case 'd':   return std::make_shared<Double>(frame);
+        case 'D':   return std::make_shared<DecimalField>(frame);
+        case 's':   return std::make_shared<ShortString>(frame);
+        case 'S':   return std::make_shared<LongString>(frame);
+        case 'A':   return std::make_shared<Array>(frame);
+        case 'T':   return std::make_shared<Timestamp>(frame);
+        case 'F':   return std::make_shared<Table>(frame);
+        case 'V':   return std::make_shared<VoidField>(frame);
         default:    return nullptr;
     }
 }

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -24,11 +24,11 @@ Table::Table(InBuffer &frame)
         bytesToRead -= (uint32_t)(name.size() + 1);
 
         // get the field
-        Field *field = Field::decode(frame);
+        auto field = Field::decode(frame);
         if (!field) continue;
 
         // add field
-        _fields[name] = std::shared_ptr<Field>(field);
+        _fields[name] = move(field);
 
         // subtract size
         bytesToRead -= (uint32_t)field->size();

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -28,7 +28,7 @@ Table::Table(InBuffer &frame)
         if (!field) continue;
 
         // add field
-        _fields[name] = move(field);
+        _fields[name] = std::move(field);
 
         // subtract size
         bytesToRead -= (uint32_t)field->size();


### PR DESCRIPTION
Noticed this while investigating project 35447 (or see 40168). The std::shared_ptr constructor, when given a raw pointer, is forced to allocate its control block separately. When using std::make_shared, it is able to allocate sizeof(control block) + sizeof(T) in one allocation.