### PR TITLE
Fix: cannot call size() on a moved-from Field

### DIFF
--- a/src/table.cpp
+++ b/src/table.cpp
@@ -27,11 +27,11 @@ Table::Table(InBuffer &frame)
         auto field = Field::decode(frame);
         if (!field) continue;
 
-        // add field
-        _fields[name] = std::move(field);
-
         // subtract size
         bytesToRead -= (uint32_t)field->size();
+
+        // add field
+        _fields[name] = std::move(field);
     }
 }
 


### PR DESCRIPTION
Solution is to swap the statements.

This was regressed in 7532f5769de145b1744c4f737a3d6964a6c94509.

see project 40173