### PR TITLE
Print a better error message

### DIFF
--- a/src/linux_tcp/openssl.cpp
+++ b/src/linux_tcp/openssl.cpp
@@ -355,6 +355,20 @@ void ERR_clear_error()
 }
 
 /**
+ *  Print errors via a callback
+ *  @param  cb
+ *  @param  u
+ */
+void ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u), void *u)
+{
+    // the actual function
+    static Function<decltype(::ERR_print_errors_cb)> func(handle, "ERR_print_errors_cb");
+
+    // call the openssl function
+    func(cb, u);
+}
+
+/**
  *  End of namespace
  */
 }}

--- a/src/linux_tcp/openssl.h
+++ b/src/linux_tcp/openssl.h
@@ -53,6 +53,7 @@ long     SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg);
 long     SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg);
 int      SSL_CTX_set_default_verify_paths(SSL_CTX *ctx);
 void     ERR_clear_error(void);
+void     ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u), void *u);
 
 /**
  *  End of namespace

--- a/src/linux_tcp/sslconnected.h
+++ b/src/linux_tcp/sslconnected.h
@@ -134,17 +134,17 @@ private:
         case SSL_ERROR_WANT_READ:
             // remember state
             _state = state;
-            
+
             // the operation must be repeated when readable
             _parent->onIdle(this, _socket, readable);
-            
+
             // allow chaining
             return true;
-        
+
         case SSL_ERROR_WANT_WRITE:
             // remember state
             _state = state;
-            
+
             // wait until socket becomes writable again
             _parent->onIdle(this, _socket, readable | writable);
 
@@ -156,30 +156,30 @@ private:
         case SSL_ERROR_NONE:
             // we're ready for the next instruction from userspace
             _state = state_idle;
-            
+
             // if we still have an outgoing buffer we want to send out data, otherwise we just read
             _parent->onIdle(this, _socket, _out ? readable | writable : readable);
 
             // nothing is wrong, we are done
             return true;
-            
+
         default:
-        {
             // we are now in an error state
             _state = state_error;
 
-            // get a human-readable error string
-            const SslErrorPrinter printer{error};
+            {
+                // get a human-readable error string
+                const SslErrorPrinter printer{error};
 
-            // ensure it is null-terminated
-            const std::string message{printer.data(), printer.size()};
+                // ensure it is null-terminated
+                const std::string message{printer.data(), printer.size()};
 
-            // report an error to user-space
-            _parent->onError(this, message.data());
+                // report an error to user-space
+                _parent->onError(this, message.data());
+            }
 
             // ssl level error, we have to tear down the tcp connection
             return false;
-        }
         }
     }
     

--- a/src/linux_tcp/sslconnected.h
+++ b/src/linux_tcp/sslconnected.h
@@ -169,10 +169,7 @@ private:
 
             {
                 // get a human-readable error string
-                const SslErrorPrinter printer{error};
-
-                // ensure it is null-terminated
-                const std::string message{printer.data(), printer.size()};
+                const SslErrorPrinter message{error};
 
                 // report an error to user-space
                 _parent->onError(this, message.data());

--- a/src/linux_tcp/sslconnected.h
+++ b/src/linux_tcp/sslconnected.h
@@ -167,7 +167,7 @@ private:
             _state = state_error;
 
             // report an error to user-space
-            _parent->onError(this, "ssl protocol error");
+            _parent->onError(this, strerror(error).data());
 
             // ssl level error, we have to tear down the tcp connection
             return false;
@@ -303,6 +303,73 @@ private:
         
         // proceed with the write operation or the event loop
         return _out && isWritable() ? write(monitor) : proceed();
+    }
+
+    /**
+     *  Get the error description of the returnvalue of SSL_get_error
+     *  @param[in]  returnvalue  The return value of SSL_get_error
+     *  @param      bp           Pointer to a BIO in case the error is SSL_ERROR_SSL
+     *  @return     A static string describing the error, or nullptr.
+     *              In the case of a nullptr, the passed-in BIO describes the error.
+     */
+    static const char *strerror(int returnvalue, ::BIO *bp)
+    {
+        // check the return value of the SSL_get_error function, which has a very unfortunate name.
+        switch (returnvalue)
+        {
+            // It can be a syscall error.
+            case SSL_ERROR_SYSCALL:
+
+                // The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected
+                // EOF from the peer. This will be properly reported as SSL_ERROR_SSL
+                // with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the
+                // OpenSSL 3.0 release because it is truly a TLS protocol error to
+                // terminate the connection without a SSL_shutdown().
+                if (errno == 0) return "SSL_R_UNEXPECTED_EOF_WHILE_READING";
+
+                // Otherwise we ask the OS for a description of the error.
+                return ::strerror(errno);
+
+            // It can be an error in OpenSSL. In that case the error stack contains
+            // more information. The documentation notes: if this error occurs then
+            // no further I/O operations should be performed on the connection and
+            // SSL_shutdown() must not be called.
+            case SSL_ERROR_SSL:
+
+                // invoke the convenience function to extract the whole error stack
+                ::ERR_print_errors(bp);
+
+                // we return nullptr because the error is described by the bio
+                return nullptr;
+
+            default:
+                // we don't know what kind of error this is
+                return "unknown ssl error";
+        }
+    }
+
+    /**
+     *  Get a human-readable string from the return value of SSL_get_error in case it's an error.
+     *  @param[in]  returnvalue  The return value. Must not be a non-error.
+     *  @return     std::string describing the error.
+     */
+    static std::string strerror(int returnvalue)
+    {
+        // create a BIO so we can call our strerror overload
+        std::unique_ptr<::BIO, decltype(&::BIO_free)> bio(::BIO_new(::BIO_s_mem()), &::BIO_free);
+
+        // deduce the error message, and return it if it's not null
+        if (const char *message = strerror(returnvalue, bio.get())) return {message};
+
+        // the error is described in the BIO
+        // get the buffer memory structure
+        ::BUF_MEM *bufmem;
+
+        // get it from the bio
+        ::BIO_get_mem_ptr(bio.get(), &bufmem);
+
+        // ensure it's null-terminated by copying it to std::string
+        return {bufmem->data, bufmem->length};
     }
 
     

--- a/src/linux_tcp/sslerrorprinter.cpp
+++ b/src/linux_tcp/sslerrorprinter.cpp
@@ -71,7 +71,7 @@ SslErrorPrinter::SslErrorPrinter(int retval)
     case SSL_ERROR_SSL:
 
         // collect all error lines
-        ::ERR_print_errors_cb(&sslerrorprintercallback, this);
+        OpenSSL::ERR_print_errors_cb(&sslerrorprintercallback, this);
 
         // done
         break;

--- a/src/linux_tcp/sslerrorprinter.cpp
+++ b/src/linux_tcp/sslerrorprinter.cpp
@@ -26,17 +26,11 @@ namespace AMQP {
  */
 int sslerrorprintercallback(const char *str, size_t len, void *ctx)
 {
-    // cast to ourselves
-    auto *self = static_cast<SslErrorPrinter*>(ctx);
-
-    // if this is not the first line, add a newline character
-    if (!self->_message.empty()) self->_message.push_back('\n');
-
-    // store the message
-    self->_message.append(str, len);
+    // Cast to ourselves and store the error line. OpenSSL adds a newline to every error line.
+    static_cast<SslErrorPrinter*>(ctx)->_message.append(str, len);
 
     // continue with the next message
-    return 1;
+    return 0;
 }
 
 /**
@@ -72,6 +66,9 @@ SslErrorPrinter::SslErrorPrinter(int retval)
 
         // collect all error lines
         OpenSSL::ERR_print_errors_cb(&sslerrorprintercallback, this);
+
+        // remove the last newline
+        if (!_message.empty() && _message.back() == '\n') _message.pop_back();
 
         // done
         break;

--- a/src/linux_tcp/sslerrorprinter.cpp
+++ b/src/linux_tcp/sslerrorprinter.cpp
@@ -42,7 +42,6 @@ int sslerrorprintercallback(const char *str, size_t len, void *ctx)
 /**
  *  Constructor
  *  @param retval return value of SSL_get_error (must be a proper error)
- *  @throw std::bad_alloc if the BIO couldn't be allocated
  */
 SslErrorPrinter::SslErrorPrinter(int retval)
 {

--- a/src/linux_tcp/sslerrorprinter.cpp
+++ b/src/linux_tcp/sslerrorprinter.cpp
@@ -22,7 +22,7 @@ namespace AMQP {
  *  @param  str   The string
  *  @param  len   The length
  *  @param  ctx   The context (this ptr)
- *  @return       always 1 to signal to OpenSSL to continue
+ *  @return       always 0 to signal to OpenSSL to continue
  */
 int sslerrorprintercallback(const char *str, size_t len, void *ctx)
 {

--- a/src/linux_tcp/sslerrorprinter.cpp
+++ b/src/linux_tcp/sslerrorprinter.cpp
@@ -1,0 +1,93 @@
+/**
+ *  SslErrorPrinter.cpp
+ *
+ *  Implementation of SslErrorPrinter
+ *
+ *  @copyright 2021 copernica BV
+ */
+
+/**
+ *  Dependencies
+ */
+#include "sslerrorprinter.h"
+#include <cstring>
+
+/**
+ *  Begin namespace
+ */
+namespace AMQP {
+
+/**
+ *  Constructor
+ *  @param retval return value of SSL_get_error (must be a proper error)
+ *  @throw std::bad_alloc if the BIO couldn't be allocated
+ */
+SslErrorPrinter::SslErrorPrinter(int retval) : _bio(nullptr, &::BIO_free)
+{
+    // check the return value of the SSL_get_error function, which has a very unfortunate name.
+    switch (retval)
+    {
+        // It can be a syscall error.
+        case SSL_ERROR_SYSCALL:
+        {
+            // The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected
+            // EOF from the peer. This will be properly reported as SSL_ERROR_SSL
+            // with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the
+            // OpenSSL 3.0 release because it is truly a TLS protocol error to
+            // terminate the connection without a SSL_shutdown().
+            if (errno == 0) _strerror = "SSL_R_UNEXPECTED_EOF_WHILE_READING";
+
+            // Otherwise we ask the OS for a description of the error.
+            else _strerror = ::strerror(errno);
+
+            // done
+            break;
+        }
+        // It can be an error in OpenSSL. In that case the error stack contains
+        // more information. The documentation notes: if this error occurs then
+        // no further I/O operations should be performed on the connection and
+        // SSL_shutdown() must not be called.
+        case SSL_ERROR_SSL:
+        {
+            // create a new bio
+            _bio = decltype(_bio)(::BIO_new(::BIO_s_mem()), &::BIO_free);
+
+            // check if it was allocated
+            if (!_bio) throw std::bad_alloc();
+
+            // invoke the convenience function to extract the whole error stack
+            ::ERR_print_errors(_bio.get());
+
+            // get it from the bio
+            ::BIO_get_mem_ptr(_bio.get(), &_bufmem);
+
+            // done
+            break;
+        }
+        default:
+        {
+            // we don't know what kind of error this is
+            _strerror = "unknown ssl error";
+
+            // done
+            break;
+        }
+    }
+}
+
+/**
+ *  data ptr
+ *  @return const char *
+ */
+const char *SslErrorPrinter::data() const noexcept { return _strerror ? _strerror : _bufmem->data; }
+
+/**
+ *  length of the string
+ *  @return size_t
+ */
+std::size_t SslErrorPrinter::size() const noexcept { return _strerror ? std::strlen(_strerror) : _bufmem->length; }
+
+/**
+ *  End of namespace AMQP
+ */
+}

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -34,7 +34,6 @@ public:
     /**
      *  Constructor
      *  @param retval return value of SSL_get_error (must be a proper error)
-     *  @throw std::bad_alloc if the BIO couldn't be allocated
      */
     SslErrorPrinter(int retval);
 

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -120,4 +120,7 @@ public:
     std::size_t size() const noexcept { return _strerror ? std::strlen(_strerror) : _bufmem->length; }
 };
 
+/**
+ *  End of namespace AMQP
+ */
 }

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -61,7 +61,7 @@ private:
      *  @param  str   The string
      *  @param  len   The length
      *  @param  ctx   The context (this ptr)
-     *  @return       always 1 to signal to OpenSSL to continue
+     *  @return       always 0 to signal to OpenSSL to continue
      */
     friend int sslerrorprintercallback(const char *str, size_t len, void *ctx);
 };

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -1,0 +1,123 @@
+/**
+ *  SslErrorPrinter.h
+ *
+ *  Flushes the SSL error stack to a BIO.
+ *  You can get at the string content via the data() and size() methods.
+ *  After constructing an instance of this class, the SSL error stack
+ *  is empty.
+ *
+ *  @copyright 2021 copernica BV
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Dependencies
+ */
+#include "openssl.h"
+#include <cstring>
+#include <memory>
+
+/**
+ *  Begin namespace
+ */
+namespace AMQP {
+
+/**
+ *  Class declaration
+ */
+class SslErrorPrinter final
+{
+    /**
+     *  pointer to the BIO
+     *  @var unique_ptr
+     */
+    std::unique_ptr<::BIO, decltype(&::BIO_free)> _bio;
+
+    /**
+     *  pointer to the (data, size) tuple
+     *  @var ::BUF_MEM*
+     */
+    ::BUF_MEM *_bufmem = nullptr;
+
+    /**
+     *  In case of a syscall error, the static string pointing to the error
+     *  @var const char*
+     */
+    const char *_strerror = nullptr;
+
+public:
+    /**
+     *  Constructor
+     *  @throw std::bad_alloc if the BIO couldn't be allocated
+     */
+    SslErrorPrinter(int retval) : _bio(nullptr, &::BIO_free)
+    {
+        // check the return value of the SSL_get_error function, which has a very unfortunate name.
+        switch (retval)
+        {
+            // It can be a syscall error.
+            case SSL_ERROR_SYSCALL:
+            {
+                // The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected
+                // EOF from the peer. This will be properly reported as SSL_ERROR_SSL
+                // with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the
+                // OpenSSL 3.0 release because it is truly a TLS protocol error to
+                // terminate the connection without a SSL_shutdown().
+                if (errno == 0) _strerror = "SSL_R_UNEXPECTED_EOF_WHILE_READING";
+
+                // Otherwise we ask the OS for a description of the error.
+                else _strerror = ::strerror(errno);
+
+                // done
+                break;
+            }
+            // It can be an error in OpenSSL. In that case the error stack contains
+            // more information. The documentation notes: if this error occurs then
+            // no further I/O operations should be performed on the connection and
+            // SSL_shutdown() must not be called.
+            case SSL_ERROR_SSL:
+            {
+                // create a new bio
+                _bio = decltype(_bio)(::BIO_new(::BIO_s_mem()), &::BIO_free);
+
+                // check if it was allocated
+                if (!_bio) throw std::bad_alloc();
+
+                // invoke the convenience function to extract the whole error stack
+                ::ERR_print_errors(_bio.get());
+
+                // get it from the bio
+                ::BIO_get_mem_ptr(_bio.get(), &_bufmem);
+
+                // done
+                break;
+            }
+            default:
+            {
+                // we don't know what kind of error this is
+                _strerror = "unknown ssl error";
+
+                // done
+                break;
+            }
+        }
+    }
+
+    /**
+     *  data ptr
+     *  @return const char *
+     */
+    const char *data() const noexcept { return _strerror ? _strerror : _bufmem->data; }
+
+    /**
+     *  length of the string
+     *  @return size_t
+     */
+    std::size_t size() const noexcept { return _strerror ? std::strlen(_strerror) : _bufmem->length; }
+};
+
+}

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -18,7 +18,6 @@
  *  Dependencies
  */
 #include "openssl.h"
-#include <cstring>
 #include <memory>
 
 /**
@@ -52,72 +51,22 @@ class SslErrorPrinter final
 public:
     /**
      *  Constructor
+     *  @param retval return value of SSL_get_error (must be a proper error)
      *  @throw std::bad_alloc if the BIO couldn't be allocated
      */
-    SslErrorPrinter(int retval) : _bio(nullptr, &::BIO_free)
-    {
-        // check the return value of the SSL_get_error function, which has a very unfortunate name.
-        switch (retval)
-        {
-            // It can be a syscall error.
-            case SSL_ERROR_SYSCALL:
-            {
-                // The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected
-                // EOF from the peer. This will be properly reported as SSL_ERROR_SSL
-                // with reason code SSL_R_UNEXPECTED_EOF_WHILE_READING in the
-                // OpenSSL 3.0 release because it is truly a TLS protocol error to
-                // terminate the connection without a SSL_shutdown().
-                if (errno == 0) _strerror = "SSL_R_UNEXPECTED_EOF_WHILE_READING";
-
-                // Otherwise we ask the OS for a description of the error.
-                else _strerror = ::strerror(errno);
-
-                // done
-                break;
-            }
-            // It can be an error in OpenSSL. In that case the error stack contains
-            // more information. The documentation notes: if this error occurs then
-            // no further I/O operations should be performed on the connection and
-            // SSL_shutdown() must not be called.
-            case SSL_ERROR_SSL:
-            {
-                // create a new bio
-                _bio = decltype(_bio)(::BIO_new(::BIO_s_mem()), &::BIO_free);
-
-                // check if it was allocated
-                if (!_bio) throw std::bad_alloc();
-
-                // invoke the convenience function to extract the whole error stack
-                ::ERR_print_errors(_bio.get());
-
-                // get it from the bio
-                ::BIO_get_mem_ptr(_bio.get(), &_bufmem);
-
-                // done
-                break;
-            }
-            default:
-            {
-                // we don't know what kind of error this is
-                _strerror = "unknown ssl error";
-
-                // done
-                break;
-            }
-        }
-    }
+    SslErrorPrinter(int retval);
 
     /**
      *  data ptr
      *  @return const char *
      */
-    const char *data() const noexcept { return _strerror ? _strerror : _bufmem->data; }
+    const char *data() const noexcept;
 
     /**
      *  length of the string
      *  @return size_t
      */
-    std::size_t size() const noexcept { return _strerror ? std::strlen(_strerror) : _bufmem->length; }
+    std::size_t size() const noexcept;
 };
 
 /**

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -30,24 +30,6 @@ namespace AMQP {
  */
 class SslErrorPrinter final
 {
-    /**
-     *  pointer to the BIO
-     *  @var unique_ptr
-     */
-    std::unique_ptr<::BIO, decltype(&::BIO_free)> _bio;
-
-    /**
-     *  pointer to the (data, size) tuple
-     *  @var ::BUF_MEM*
-     */
-    ::BUF_MEM *_bufmem = nullptr;
-
-    /**
-     *  In case of a syscall error, the static string pointing to the error
-     *  @var const char*
-     */
-    const char *_strerror = nullptr;
-
 public:
     /**
      *  Constructor
@@ -57,7 +39,7 @@ public:
     SslErrorPrinter(int retval);
 
     /**
-     *  data ptr
+     *  data ptr (guaranteed null-terminated)
      *  @return const char *
      */
     const char *data() const noexcept;
@@ -67,6 +49,22 @@ public:
      *  @return size_t
      */
     std::size_t size() const noexcept;
+
+private:
+    /**
+     *  The error message
+     *  @var std::string
+     */
+    std::string _message;
+
+    /**
+     *  Callback used for ERR_print_errors_cb
+     *  @param  str   The string
+     *  @param  len   The length
+     *  @param  ctx   The context (this ptr)
+     *  @return       always 1 to signal to OpenSSL to continue
+     */
+    friend int sslerrorprintercallback(const char *str, size_t len, void *ctx);
 };
 
 /**

--- a/src/linux_tcp/sslerrorprinter.h
+++ b/src/linux_tcp/sslerrorprinter.h
@@ -1,7 +1,7 @@
 /**
  *  SslErrorPrinter.h
  *
- *  Flushes the SSL error stack to a BIO.
+ *  Flushes the SSL error stack to a string.
  *  You can get at the string content via the data() and size() methods.
  *  After constructing an instance of this class, the SSL error stack
  *  is empty.

--- a/src/linux_tcp/sslhandshake.h
+++ b/src/linux_tcp/sslhandshake.h
@@ -87,10 +87,7 @@ private:
     TcpState *reportError(const Monitor &monitor, int retval)
     {
         // extract a human-readable error string
-        const SslErrorPrinter printer{retval};
-
-        // ensure it's null-terminated
-        const std::string message{printer.data(), printer.size()};
+        const SslErrorPrinter message{retval};
 
         // we have an error - report this to the user
         _parent->onError(this, message.data());


### PR DESCRIPTION
~~This is still missing the dlsym wrappers.~~

This brings the internal error messages from OpenSSL all the way to the error handlers for better debugging.