### PR TITLE
Fix synchronous channel state bug

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -133,7 +133,7 @@ private:
      *
      *  @var std::queue
      */
-    std::queue<std::pair<bool, CopiedBuffer>> _queue;
+    std::queue<CopiedBuffer> _queue;
 
     /**
      *  Are we currently operating in synchronous mode? Meaning: do we first have

--- a/include/amqpcpp/copiedbuffer.h
+++ b/include/amqpcpp/copiedbuffer.h
@@ -20,6 +20,9 @@
 #include "endian.h"
 #include "frame.h"
 
+#include <ostream>
+#include <iomanip>
+
 /**
  *  Set up namespace
  */
@@ -49,6 +52,12 @@ private:
      */
     size_t _size = 0;
 
+    /**
+     *  Whether the frame is synchronous
+     *  @var bool
+     */
+    bool _synchronous = false;
+
 
 protected:
     /**
@@ -72,7 +81,8 @@ public:
      */
     CopiedBuffer(const Frame &frame) :
         _capacity(frame.totalSize()),
-        _buffer((char *)malloc(_capacity)) 
+        _buffer((char *)malloc(_capacity)),
+        _synchronous(frame.synchronous())
     {
         // tell the frame to fill this buffer
         frame.fill(*this);
@@ -94,7 +104,8 @@ public:
     CopiedBuffer(CopiedBuffer &&that) :
         _capacity(that._capacity),
         _buffer(that._buffer),
-        _size(that._size)
+        _size(that._size),
+        _synchronous(that._synchronous)
     {
         // reset the other object
         that._buffer = nullptr;
@@ -129,6 +140,27 @@ public:
     {
         // expose member
         return _size;
+    }
+
+    /**
+     *  Whether the frame is to be sent synchronously
+     *  @return bool
+     */
+    bool synchronous() const noexcept
+    {
+        // expose member
+        return _synchronous;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const CopiedBuffer &buffer)
+    {
+        os << "<CopiedBuffer, synchronous = " << buffer._synchronous << ", size = " << buffer._size;
+        if (0 < buffer._size && buffer._size < 128)
+        {
+            os << ", content: ";
+            for (size_t i = 0; i != buffer._size; ++i) os << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned>(buffer._buffer[i]) << ' ';
+        }
+        return os << '>';
     }
 };
 

--- a/include/amqpcpp/copiedbuffer.h
+++ b/include/amqpcpp/copiedbuffer.h
@@ -20,9 +20,6 @@
 #include "endian.h"
 #include "frame.h"
 
-#include <ostream>
-#include <iomanip>
-
 /**
  *  Set up namespace
  */
@@ -150,17 +147,6 @@ public:
     {
         // expose member
         return _synchronous;
-    }
-
-    friend std::ostream &operator<<(std::ostream &os, const CopiedBuffer &buffer)
-    {
-        os << "<CopiedBuffer, synchronous = " << buffer._synchronous << ", size = " << buffer._size;
-        if (0 < buffer._size && buffer._size < 128)
-        {
-            os << ", content: ";
-            for (size_t i = 0; i != buffer._size; ++i) os << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned>(buffer._buffer[i]) << ' ';
-        }
-        return os << '>';
     }
 };
 

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -38,8 +38,6 @@
 #include "basicrejectframe.h"
 #include "basicgetframe.h"
 
-#include <iostream>
-
 /**
  *  Set up namespace
  */
@@ -750,8 +748,6 @@ bool ChannelImpl::send(CopiedBuffer &&frame)
     // other frames waiting for their turn to be sent?
     if (waiting())
     {
-        // std::cerr << "we are in synchronous mode, so we must await a server response before sending this frame of size: " << frame.size() << '\n';
-
         // we need to wait until the synchronous frame has
         // been processed, so queue the frame until it was
         _queue.emplace(std::move(frame));
@@ -761,8 +757,6 @@ bool ChannelImpl::send(CopiedBuffer &&frame)
         return true;
     }
 
-    // std::cerr << "we are in asynchronous mode, so we can try sending this frame of size: " << frame.size() << '\n';
-
     // send to tcp connection
     if (!_connection->send(std::move(frame))) return false;
     
@@ -771,7 +765,6 @@ bool ChannelImpl::send(CopiedBuffer &&frame)
     // frame was sent, if this was a synchronous frame, we now have to wait
     _synchronous = frame.synchronous();
 
-    // if (wassynchronous != _synchronous) std::cerr << "synchronous state change: " << std::boolalpha << wassynchronous << " -> " << _synchronous << '\n';
     
     // done
     return true;
@@ -797,8 +790,6 @@ bool ChannelImpl::send(const Frame &frame)
     // other frames waiting for their turn to be sent?
     if (waiting())
     {
-        // std::cerr << "we are in synchronous mode, so we must await a server response before sending this frame of size: " << frame.totalSize() << '\n';
-
         // we need to wait until the synchronous frame has
         // been processed, so queue the frame until it was
         _queue.emplace(frame);
@@ -808,17 +799,11 @@ bool ChannelImpl::send(const Frame &frame)
         return true;
     }
 
-    // std::cerr << "we are in asynchronous mode, so we can try sending this frame of size: " << frame.totalSize() << '\n';
-
     // send to tcp connection
     if (!_connection->send(frame)) return false;
 
-    // auto wassynchronous = _synchronous;
-    
     // frame was sent, if this was a synchronous frame, we now have to wait
     _synchronous = frame.synchronous();
-
-    // if (wassynchronous != _synchronous) std::cerr << "synchronous state change: " << std::boolalpha << wassynchronous << " -> " << _synchronous << '\n';
     
     // done
     return true;
@@ -841,7 +826,6 @@ uint32_t ChannelImpl::maxPayload() const
  */
 void ChannelImpl::flush()
 {
-    // std::cerr << "FLUSH start\n";
     // we are no longer waiting for synchronous operations
     _synchronous = false;
 
@@ -860,8 +844,6 @@ void ChannelImpl::flush()
         // mark as synchronous if necessary
         _synchronous = buffer.synchronous();
 
-        // std::cerr << "sending " << buffer << '\n';
-
         // send it over the connection
         _connection->send(std::move(buffer));
 
@@ -869,7 +851,6 @@ void ChannelImpl::flush()
         if (!monitor.valid()) return;
     }
 
-//     std::cerr << "FLUSH end\n";
 }
 
 /**

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -757,14 +757,14 @@ bool ChannelImpl::send(CopiedBuffer &&frame)
         return true;
     }
 
+    // is this a synchronous frame?
+    bool syncframe = frame.synchronous();
+
     // send to tcp connection
     if (!_connection->send(std::move(frame))) return false;
     
-    // auto wassynchronous = _synchronous;
-
     // frame was sent, if this was a synchronous frame, we now have to wait
-    _synchronous = frame.synchronous();
-
+    _synchronous = syncframe;
     
     // done
     return true;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,3 @@
-a.out
+address
+inject
+rejectall

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 CPP				= g++
 CPPFLAGS		= -Wall -I. -O3 -flto -std=c++17 -ggdb3
-LDFLAGS			= -lamqpcpp -lcopernica_event -lcopernica_network -lev -lpthread -ldl
+LDFLAGS			= -lamqpcpp -lcopernica_event -lcopernica_network -lev -lpthread -ldl -lssl -lcrypto
 SOURCES			= $(wildcard *.cpp)
 PROGRAMS		= $(SOURCES:%.cpp=%)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 CPP			= g++
-CPPFLAGS		= -Wall -c -I. -O2 -flto -std=c++11 -g
+CPPFLAGS		= -Wall -c -I. -O0 -flto -std=c++17 -ggdb3
 LD			= g++
-LDFLAGS			= -lamqpcpp -lcopernica_event -lcopernica_network -lev
+LDFLAGS			= -lamqpcpp -lcopernica_event -lcopernica_network -lev -lpthread -ldl
 RESULT			= a.out
 SOURCES			= $(wildcard *.cpp)
 OBJECTS			= $(SOURCES:%.cpp=%.o)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,18 +1,13 @@
-CPP			= g++
-CPPFLAGS		= -Wall -c -I. -O0 -flto -std=c++17 -ggdb3
-LD			= g++
+CPP				= g++
+CPPFLAGS		= -Wall -I. -O3 -flto -std=c++17 -ggdb3
 LDFLAGS			= -lamqpcpp -lcopernica_event -lcopernica_network -lev -lpthread -ldl
-RESULT			= a.out
 SOURCES			= $(wildcard *.cpp)
-OBJECTS			= $(SOURCES:%.cpp=%.o)
+PROGRAMS		= $(SOURCES:%.cpp=%)
 
-all:	${OBJECTS} ${RESULT}
-
-${RESULT}: ${OBJECTS}
-	${LD} -o $@ ${OBJECTS} ${LDFLAGS}
+all:	${PROGRAMS}
 
 clean:
-	${RM} *.obj *~* ${OBJECTS} ${RESULT}
+	${RM} *~* ${PROGRAMS}
 
-${OBJECTS}:
-	${CPP} ${CPPFLAGS} -o $@ ${@:%.o=%.cpp}
+%: %.cpp
+	${CPP} $< ${CPPFLAGS} ${LDFLAGS} -o $@

--- a/tests/address.cpp
+++ b/tests/address.cpp
@@ -18,7 +18,6 @@
  *  @param  argv
  *  @return int
  */
-/*
 int main(int argc, const char *argv[])
 {
     // iterate over the arguments
@@ -38,4 +37,3 @@ int main(int argc, const char *argv[])
     // done
     return 0;
 }
-*/

--- a/tests/rejectall.cpp
+++ b/tests/rejectall.cpp
@@ -1,0 +1,115 @@
+#include <amqpcpp.h>
+#include <amqpcpp/libev.h>
+#include <iostream>
+#include <optional>
+
+#define TRACE std::cerr << __PRETTY_FUNCTION__ << " line " << __LINE__ << '\n'
+
+struct MyHandler final : public AMQP::LibEvHandler, public std::enable_shared_from_this<MyHandler>
+{
+    struct ev_loop *loop;
+    AMQP::TcpConnection *conn = nullptr;
+    std::optional<AMQP::TcpChannel> channel;
+    MyHandler(struct ev_loop *loop) : AMQP::LibEvHandler(loop), loop(loop) {}
+    ~MyHandler() override = default;
+    void onAttached(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onAttached(connection);
+        TRACE;
+    }
+    void onConnected(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onConnected(connection);
+        TRACE;
+    }
+    bool onSecuring(AMQP::TcpConnection *connection, SSL *ssl) override
+    {
+        TRACE;
+        return AMQP::LibEvHandler::onSecuring(connection, ssl);
+    }
+    bool onSecured(AMQP::TcpConnection *connection, const SSL *ssl) override
+    {
+        TRACE;
+        return AMQP::LibEvHandler::onSecured(connection, ssl);
+    }
+    void onProperties(AMQP::TcpConnection *connection, const AMQP::Table &server, AMQP::Table &client) override
+    {
+        AMQP::LibEvHandler::onProperties(connection, server, client);
+        TRACE;
+    }
+    uint16_t onNegotiate(AMQP::TcpConnection *connection, uint16_t interval) override
+    {
+        TRACE;
+        return AMQP::LibEvHandler::onNegotiate(connection, interval);
+    }
+    void onReady(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onReady(connection);
+        TRACE;
+
+        conn = connection;
+        channel.emplace(conn);
+        channel->onError([weakself = weak_from_this()](const char *message)
+        {
+            if (auto self = weakself.lock()) self->conn->close();
+        });
+        channel->consume("my_test_queue")
+            .onReceived([self = shared_from_this()](const AMQP::Message &message, uint64_t deliveryTag, bool redelivered)
+            {
+                std::cerr << "got message with delivery tag " << deliveryTag << '\n';
+
+                // message body
+                message.body();
+
+                // message size
+                message.size();
+
+                // self->channel->ack or self->channel->reject the deliveryTag
+                self->channel->reject(deliveryTag);
+            })
+            .onSuccess([self = shared_from_this()]()
+            {
+                std::cerr << "consuming from queue now\n";
+            })
+            .onError([self = shared_from_this()](const char *message)
+            {
+                std::cerr << "failed to consume from queue: " << message << '\n';
+            });
+    }
+    void onHeartbeat(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onHeartbeat(connection);
+        TRACE;
+    }
+    void onError(AMQP::TcpConnection *connection, const char *message) override
+    {
+        AMQP::LibEvHandler::onError(connection, message);
+        TRACE;
+    }
+    void onClosed(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onClosed(connection);
+        TRACE;
+    }
+    void onLost(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onLost(connection);
+        TRACE;
+    }
+    void onDetached(AMQP::TcpConnection *connection) override
+    {
+        AMQP::LibEvHandler::onDetached(connection);
+        TRACE;
+    }
+
+};
+
+int main(const int argc, const char **argv)
+{
+    const AMQP::Address address(argv[1]);
+    auto *loop = ev_default_loop();
+    auto handler = std::make_shared<MyHandler>(loop);
+    AMQP::TcpConnection connection(handler.get(), address);
+    ev_run(loop);
+    return EXIT_SUCCESS;
+}

--- a/tests/rejectall.cpp
+++ b/tests/rejectall.cpp
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <optional>
 
-#define TRACE std::cerr << __PRETTY_FUNCTION__ << " line " << __LINE__ << '\n'
-
 struct MyHandler final : public AMQP::LibEvHandler, public std::enable_shared_from_this<MyHandler>
 {
     struct ev_loop *loop;
@@ -26,41 +24,9 @@ struct MyHandler final : public AMQP::LibEvHandler, public std::enable_shared_fr
 
     ~MyHandler() override = default;
 
-    void onAttached(AMQP::TcpConnection *connection) override
-    {
-        AMQP::LibEvHandler::onAttached(connection);
-        TRACE;
-    }
-    void onConnected(AMQP::TcpConnection *connection) override
-    {
-        AMQP::LibEvHandler::onConnected(connection);
-        TRACE;
-    }
-    bool onSecuring(AMQP::TcpConnection *connection, SSL *ssl) override
-    {
-        TRACE;
-        return AMQP::LibEvHandler::onSecuring(connection, ssl);
-    }
-    bool onSecured(AMQP::TcpConnection *connection, const SSL *ssl) override
-    {
-        TRACE;
-        return AMQP::LibEvHandler::onSecured(connection, ssl);
-    }
-    void onProperties(AMQP::TcpConnection *connection, const AMQP::Table &server, AMQP::Table &client) override
-    {
-        AMQP::LibEvHandler::onProperties(connection, server, client);
-        TRACE;
-    }
-    uint16_t onNegotiate(AMQP::TcpConnection *connection, uint16_t interval) override
-    {
-        TRACE;
-        return AMQP::LibEvHandler::onNegotiate(connection, interval);
-    }
     void onReady(AMQP::TcpConnection *connection) override
     {
         AMQP::LibEvHandler::onReady(connection);
-        TRACE;
-
         conn = connection;
         channel.emplace(conn);
         channel->onError([weakself = weak_from_this()](const char *message)
@@ -83,35 +49,14 @@ struct MyHandler final : public AMQP::LibEvHandler, public std::enable_shared_fr
                 std::cerr << "failed to consume from queue \"" << self->queueName << "\": " << message << '\n';
             });
     }
-    // void onHeartbeat(AMQP::TcpConnection *connection) override
-    // {
-    //     AMQP::LibEvHandler::onHeartbeat(connection);
-    //     TRACE;
-    // }
     void onError(AMQP::TcpConnection *connection, const char *message) override
     {
         AMQP::LibEvHandler::onError(connection, message);
-        TRACE;
-    }
-    void onClosed(AMQP::TcpConnection *connection) override
-    {
-        AMQP::LibEvHandler::onClosed(connection);
-        TRACE;
-    }
-    void onLost(AMQP::TcpConnection *connection) override
-    {
-        AMQP::LibEvHandler::onLost(connection);
-        TRACE;
-    }
-    void onDetached(AMQP::TcpConnection *connection) override
-    {
-        AMQP::LibEvHandler::onDetached(connection);
-        TRACE;
+        std::cerr << "connection error: " << message << '\n';
     }
 
     void onTimeout()
     {
-        TRACE;
         if (!channel) return;
 
         AMQP::Table properties;

--- a/tests/rejectall.py
+++ b/tests/rejectall.py
@@ -1,0 +1,69 @@
+"""
+Requires aio-pika:
+
+    pip3 install aio-pika
+
+"""
+
+from typing import Tuple
+import asyncio
+import aio_pika
+import sys
+
+
+PROPERTIES = {
+    "x-queue-mode": "lazy",
+    "x-dead-letter-exchange": "",
+    "x-dead-letter-routing-key": "in"
+}
+
+async def declare_queue(channel: aio_pika.Channel) -> aio_pika.Queue:
+    """
+    Convenience function to declare a queue with fixed properties.
+    """
+    return await channel.declare_queue(sys.argv[3], durable=True, arguments=PROPERTIES)
+
+
+async def process_message(message: aio_pika.IncomingMessage) -> None:
+    """
+    Reject.
+    """
+    await message.reject()
+
+
+async def periodic_redeclare(channel: aio_pika.Channel) -> None:
+    """
+    Periodically redeclare a queue. This allows us to read the message count in the
+    queue of interest. When the message count reaches zero, stop the loop.
+    """
+    while True:
+        await asyncio.sleep(5.0)
+        queue = await declare_queue(channel)
+        if queue.declaration_result.message_count == 0:
+            break
+    asyncio.get_event_loop().stop()
+
+
+async def make_connection(loop: asyncio.AbstractEventLoop) -> Tuple[aio_pika.RobustConnection, aio_pika.RobustChannel]:
+    """
+    Set up a secure connection and start consuming from the queue provided in sys.argv
+    """
+    connection: aio_pika.RobustConnection = await aio_pika.connect_robust(sys.argv[1], loop=loop, ssl=True)
+    channel = await connection.channel(publisher_confirms=False)
+    await channel.set_qos(prefetch_count=int(sys.argv[2]))
+    queue = await declare_queue(channel)
+    await queue.consume(process_message)
+    return connection, channel
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    connection, channel = loop.run_until_complete(make_connection(loop))
+    try:
+        loop.create_task(periodic_redeclare(channel))
+        loop.run_forever()
+    finally:
+        loop.run_until_complete(channel.close())
+        loop.run_until_complete(connection.close())
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()


### PR DESCRIPTION
This fixes an issue where we "forgot" whether a pending frame is synchronous or not.

This information is now stored inside of the CopiedBuffer class.