### PR TITLE
Fixup sync handling for CopiedBuffer

### DIFF
--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -133,7 +133,7 @@ private:
      *
      *  @var std::queue
      */
-    std::queue<std::pair<bool, CopiedBuffer>> _queue;
+    std::queue<CopiedBuffer> _queue;
 
     /**
      *  Are we currently operating in synchronous mode? Meaning: do we first have
@@ -609,8 +609,9 @@ public:
     /**
      *  Signal the channel that a synchronous operation was completed, and that any
      *  queued frames can be sent out.
+     *  @return false if an error on the connection level occurred, true if not
      */
-    void flush();
+    bool flush();
 
     /**
      *  Report to the handler that the channel is opened

--- a/include/amqpcpp/copiedbuffer.h
+++ b/include/amqpcpp/copiedbuffer.h
@@ -49,6 +49,12 @@ private:
      */
     size_t _size = 0;
 
+    /**
+     *  Whether the frame is synchronous
+     *  @var bool
+     */
+    bool _synchronous = false;
+
 
 protected:
     /**
@@ -72,7 +78,8 @@ public:
      */
     CopiedBuffer(const Frame &frame) :
         _capacity(frame.totalSize()),
-        _buffer((char *)malloc(_capacity)) 
+        _buffer((char *)malloc(_capacity)),
+        _synchronous(frame.synchronous())
     {
         // tell the frame to fill this buffer
         frame.fill(*this);
@@ -94,7 +101,8 @@ public:
     CopiedBuffer(CopiedBuffer &&that) :
         _capacity(that._capacity),
         _buffer(that._buffer),
-        _size(that._size)
+        _size(that._size),
+        _synchronous(that._synchronous)
     {
         // reset the other object
         that._buffer = nullptr;
@@ -129,6 +137,16 @@ public:
     {
         // expose member
         return _size;
+    }
+
+    /**
+     *  Whether the frame is to be sent synchronously
+     *  @return bool
+     */
+    bool synchronous() const noexcept
+    {
+        // expose member
+        return _synchronous;
     }
 };
 


### PR DESCRIPTION
Using a program like below, it's possible for the throttle to interleave queue declare requests, which should be sync, with publish frames. The diff fixes this.

```cpp
#include <amqpcpp.h>
#include <amqpcpp/libev.h>
#include <iostream>
#include <optional>
#include <random>

#define TRACE std::cerr << __PRETTY_FUNCTION__ << " line " << __LINE__ << '\n'

std::vector<char> makeRandomMessage(const size_t size)
{
    std::vector<char> result;
    result.reserve(size);
    std::generate_n(std::back_inserter(result), size, []()
    {
        static std::random_device seed;
        static std::mt19937 engine(seed());
        static std::uniform_int_distribution<char> distribution('A', 'z');
        return distribution(engine);
    });
    return result;
}

struct MyHandler final : public AMQP::LibEvHandler, public std::enable_shared_from_this<MyHandler>
{
    struct ev_loop *loop = nullptr;
    ev_timer *timer = nullptr;
    AMQP::TcpConnection *conn = nullptr;
    std::optional<AMQP::TcpChannel> channel;
    std::optional<AMQP::Reliable<AMQP::Throttle>> throttle;
    ev_idle idle;
    size_t messageCount = 0;
    size_t messageSize = 0;
    const char *queueName = nullptr;
    size_t current = 0;

    MyHandler(struct ev_loop *loop, size_t messageCount, size_t messageSize, const char *queueName) :
        AMQP::LibEvHandler(loop),
        loop(loop),
        messageCount(messageCount),
        messageSize(messageSize),
        queueName(queueName)
    {
        ev_idle_init(&idle, idlecallback);
        idle.data = this;
    }

    ~MyHandler() override
    {
        ev_idle_stop(loop, &idle);
    }

    void onAttached(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onAttached(connection);
        TRACE;
    }
    void onConnected(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onConnected(connection);
        TRACE;
    }
    bool onSecuring(AMQP::TcpConnection *connection, SSL *ssl) override
    {
        TRACE;
        return AMQP::LibEvHandler::onSecuring(connection, ssl);
    }
    bool onSecured(AMQP::TcpConnection *connection, const SSL *ssl) override
    {
        TRACE;
        return AMQP::LibEvHandler::onSecured(connection, ssl);
    }
    void onProperties(AMQP::TcpConnection *connection, const AMQP::Table &server, AMQP::Table &client) override
    {
        AMQP::LibEvHandler::onProperties(connection, server, client);
        TRACE;
    }
    uint16_t onNegotiate(AMQP::TcpConnection *connection, uint16_t interval) override
    {
        TRACE;
        return AMQP::LibEvHandler::onNegotiate(connection, interval);
    }
    void onReady(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onReady(connection);
        TRACE;

        conn = connection;
        channel.emplace(conn);
        throttle.emplace(*channel, 1);
        throttle->onError([weakself = weak_from_this()](const char *message)
        {
            if (auto self = weakself.lock()) self->conn->close();
        });
        std::cerr << "publishing " << messageCount << " messages each of size " << messageSize << " bytes to " << queueName << " ...\n";
        ev_idle_start(loop, &idle);
    }
    void onError(AMQP::TcpConnection *connection, const char *message) override
    {
        AMQP::LibEvHandler::onError(connection, message);
        TRACE;
        std::cerr << "connection error: " << message << '\n';
    }
    void onClosed(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onClosed(connection);
        TRACE;
    }
    void onLost(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onLost(connection);
        TRACE;
    }
    void onDetached(AMQP::TcpConnection *connection) override
    {
        AMQP::LibEvHandler::onDetached(connection);
        TRACE;
    }

    void onIdle()
    {
        ev_idle_stop(loop, &idle);
        for (size_t i = 0; i != 256; ++i, ++current)
        {
            if (current == messageCount)
            {
                throttle->close().onFinalize([self = shared_from_this()]()
                {
                    std::cerr << "done publishing messages, closing connection\n";
                    self->conn->close();
                });
                return;
            }
            const auto msg = makeRandomMessage(messageSize);
            throttle->publish("", queueName, msg.data(), msg.size());
        }
        ev_idle_start(loop, &idle);
    }

    void onTimeout()
    {
        if (!channel) return;

        AMQP::Table properties;
        // properties["x-dead-letter-exchange"] = "";
        // properties["x-dead-letter-routing-key"] = "in";
        // properties["x-queue-mode"] = "lazy";

        channel->declareQueue(queueName, AMQP::durable, properties)
            .onSuccess([self = shared_from_this()](const std::string &name, uint32_t messagecount, uint32_t consumercount)
            {
                std::cerr << "declare queue was a success: " << name << ' ' << messagecount << ' ' << consumercount << '\n';
                if (self->channel && messagecount == 0)
                {
                    std::cerr << "cancelling consumer\n";
                    self->cancel();
                }
            })
            .onError([self = shared_from_this()](const char *message)
            {
                std::cerr << "error declaring queue: " << message << '\n';
                self->cancel();
            });
    }

    void cancel()
    {
        if (timer)
        {
            std::cerr << "stopping timer\n";
            ev_timer_stop(loop, timer);
            timer = nullptr;
        }
        if (throttle)
        {
            std::cerr << "closing channel\n";
            throttle->close().onFinalize([self = shared_from_this()]()
            {
                std::cerr << "channel closed\n";
                std::cerr << "closing connection\n";
                self->conn->close();
            });
            channel.reset();
            throttle.reset();
        }
    }

    static void idlecallback(struct ev_loop *loop, ev_idle *idle, int flags)
    {
        static_cast<MyHandler*>(idle->data)->onIdle();
    }

    static void timercallback(struct ev_loop *loop, ev_timer *timer, int flags)
    {
        static_cast<MyHandler*>(timer->data)->onTimeout();
    }
};

int main(const int argc, const char **argv)
{
    OPENSSL_init_ssl(0, nullptr);
    const AMQP::Address address(argv[1]);
    auto *loop = ev_default_loop();
    ev_timer timer;
    ev_timer_init(&timer, MyHandler::timercallback, 0.1, 0.1);
    auto handler = std::make_shared<MyHandler>(loop, std::atoi(argv[2]), std::atoi(argv[3]), argv[4]);
    handler->timer = &timer;
    timer.data = handler.get();
    ev_timer_start(loop, &timer);
    AMQP::TcpConnection connection(handler.get(), address);
    ev_run(loop);
    return EXIT_SUCCESS;
}
```