### PR TITLE
Stop timer at Wrapper::onExpired() when server is inactive (#420)

### DIFF
--- a/include/amqpcpp/libev.h
+++ b/include/amqpcpp/libev.h
@@ -254,9 +254,11 @@ private:
             {
                 // the server was inactive for a too long period of time, reset state
                 _next = _expire = 0.0; _timeout = 0;
-                
+
+                ev_timer_stop(_loop, &_timer);
+
                 // close the connection because server was inactive
-                return (void)_connection->close();
+                return (void)_connection->close(true);
             }
             else if (now >= _next)
             {


### PR DESCRIPTION
Note, that this uses close(true) - do not wait for a lot of time since server hasn't responded  for about 1.5 timeout seconds.

- [ ] check ev_ref/ev_unref