### PR TITLE
Use one-shot expirations instead of intervals for the libev backend

### DIFF
--- a/include/amqpcpp/libev.h
+++ b/include/amqpcpp/libev.h
@@ -269,7 +269,7 @@ private:
             }
             
             // reset the timer to trigger again later
-            _timer.repeat = std::min(_next, _expire) - now;
+            ev_timer_set(&_timer, std::min(_next, _expire) - now, 0.0);
             
             // restart the timer
             ev_timer_again(_loop, &_timer);
@@ -366,7 +366,7 @@ private:
             _expire = now + _timeout * 1.5;
 
             // find the earliest thing that expires
-            _timer.repeat = std::min(_next, _expire) - now;
+            ev_timer_set(&_timer, std::min(_next, _expire) - now, 0.0);
             
             // restart the timer
             ev_timer_again(_loop, &_timer);


### PR DESCRIPTION
As per the discussion in #421, we want to use one-shot timers and re-arm them in the expire callbacks. I'm unsure what the forward progress is of #421 so here is another mergeable pull request.

The `ev_timer_set` is a macro which expands to:

```cpp
#define ev_timer_set(ev,after_,repeat_)      do { ((ev_watcher_time *)(ev))->at = (after_); (ev)->repeat = (repeat_); } while (0)
```

As mentioned by @happykeyboard, in the `start` method we also modify the timer and we should probably use the same code in both places. However it was mentioned that "reconnect times increase". I don't know how this could result in different behavior because `ev_timer_set` clears out the interval member variable.