### PR TITLE
Remove ev_timer_again calls

### DIFF
--- a/include/amqpcpp/libev.h
+++ b/include/amqpcpp/libev.h
@@ -271,9 +271,6 @@ private:
             // reset the timer to trigger again later
             ev_timer_set(&_timer, std::min(_next, _expire) - now, 0.0);
             
-            // restart the timer
-            ev_timer_again(_loop, &_timer);
-            
             // and because the timer is running again, we restore the refcounter
             ev_unref(_loop);
         }
@@ -367,9 +364,6 @@ private:
 
             // find the earliest thing that expires
             ev_timer_set(&_timer, std::min(_next, _expire) - now, 0.0);
-            
-            // restart the timer
-            ev_timer_again(_loop, &_timer);
             
             // expose the accepted interval
             return _timeout;

--- a/include/amqpcpp/libev.h
+++ b/include/amqpcpp/libev.h
@@ -267,9 +267,12 @@ private:
                 // sent only after _timout/2 seconds again _from now_ (no catching up)
                 _next = now + std::max(_timeout / 2, 1);
             }
-            
+
             // reset the timer to trigger again later
             ev_timer_set(&_timer, std::min(_next, _expire) - now, 0.0);
+
+            // and start it again
+            ev_timer_start(_loop, &_timer);
             
             // and because the timer is running again, we restore the refcounter
             ev_unref(_loop);


### PR DESCRIPTION
The documentation says about this function:

    If the timer is started but non-repeating, stop it (as if it timed out).

The timers are non-repeating, so we don't want this call.

https://linux.die.net/man/3/ev