### PR TITLE
Timeout issues

### DIFF
--- a/src/linux_tcp/tcpresolver.h
+++ b/src/linux_tcp/tcpresolver.h
@@ -120,6 +120,12 @@ private:
 
                 // turn socket into a non-blocking socket and set the close-on-exec bit
                 fcntl(_socket, F_SETFL, O_NONBLOCK | O_CLOEXEC);
+                
+                // we set the 'keepalive' option so that we automatically detect if the peer is dead
+                int keepalive = 1;
+                
+                // set the keepalive option
+                setsockopt(_socket, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
 
                 // try to connect non-blocking
                 if (connect(_socket, addresses[i]->ai_addr, addresses[i]->ai_addrlen) == 0) break;


### PR DESCRIPTION
While working on the svnslave application (copernica-specific thing) we discovered that connections were not always correctly closed down.

- If a heartbeat was missed because of a broken network connection, the elegant AMQP close handshake was started - which (of course) never completed because of the network being broken.
- The TCP level also did not detect this, because the KEEPALIVE option was not activated.
- When testing with very short heartbeat intervals, we forgot to send out heartbeats (because the initial timer was still set to 60 seconds).

This has all been fixed in this pull request.