### PR TITLE
Fix TCP module build for old gcc versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,9 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
 )
 
 if(AMQP-CPP_LINUX_TCP)
-    target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
+    find_package(Threads REQUIRED)
+
+    target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS} Threads::Threads)
     # Find OpenSSL and provide include dirs
     find_package(OpenSSL REQUIRED)
     target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
TCP module uses `std::thread` internally, so it is required to link pthreads
explicitly when building with old gcc versions.