### PR TITLE
add x-message-deduplication exchange type

### DIFF
--- a/include/amqpcpp/exchangetype.h
+++ b/include/amqpcpp/exchangetype.h
@@ -25,7 +25,8 @@ enum ExchangeType
     direct,
     topic,
     headers,
-    consistent_hash
+    consistent_hash,
+    message_deduplication
 };
 
 /**

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -290,6 +290,7 @@ Deferred &ChannelImpl::declareExchange(const std::string &name, ExchangeType typ
     else if (type == ExchangeType::topic)           exchangeType = "topic";
     else if (type == ExchangeType::headers)         exchangeType = "headers";
     else if (type == ExchangeType::consistent_hash) exchangeType = "x-consistent-hash";
+    else if (type == ExchangeType::consistent_hash) exchangeType = "x-message-deduplication";
 
     // the boolean options
     bool passive = (flags & AMQP::passive) != 0;


### PR DESCRIPTION
This exchange type exist on RabbitMQ server with the plugin rabbitmq_message_deduplication
This plugin code is available here: https://github.com/noxdafox/rabbitmq-message-deduplication