### PR TITLE
Always move callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ auto callback = [](const std::string &name, int msgcount, int consumercount) {
 };
 
 // declare the queue, and install the callback that is called on success
-channel.declareQueue("myQueue").onSuccess(callback);
+channel.declareQueue("myQueue").onSuccess(std::move(callback));
 ````
 
 Just like many others methods in the Channel class, the declareQueue() method

--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -77,9 +77,9 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    void onReady(const SuccessCallback &callback)
+    void onReady(SuccessCallback&&callback)
     {
-        _implementation->onReady(callback);
+        _implementation->onReady(std::move(callback));
     }
 
     /**
@@ -90,9 +90,9 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    void onError(const ErrorCallback &callback)
+    void onError(ErrorCallback&&callback)
     {
-        _implementation->onError(callback);
+        _implementation->onError(std::move(callback));
     }
 
     /**

--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -76,8 +76,9 @@ public:
      *  times will remove the old callback.
      *
      *  @param  callback    the callback to execute
-     */
-    void onReady(SuccessCallback&&callback)
+     */         
+    inline void onReady(const SuccessCallback& callback) { return onReady(SuccessCallback(callback)); }
+    void onReady(SuccessCallback&& callback)
     {
         _implementation->onReady(std::move(callback));
     }
@@ -90,7 +91,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    void onError(ErrorCallback&&callback)
+    inline void onError(const ErrorCallback& callback) { return onError(ErrorCallback(callback)); }
+    void onError(ErrorCallback&& callback)
     {
         _implementation->onError(std::move(callback));
     }

--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -212,10 +212,10 @@ public:
      *  Callback that is called when the channel was succesfully created.
      *  @param  callback    the callback to execute
      */
-    void onReady(const SuccessCallback &callback)
+    void onReady(SuccessCallback&&callback)
     {
         // store callback
-        _readyCallback = callback;
+        _readyCallback = std::move(callback);
 
         // direct call if channel is already ready
         if (_state == state_ready && callback) callback();
@@ -229,7 +229,7 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    void onError(const ErrorCallback &callback);
+    void onError(ErrorCallback&&callback);
 
     /**
      *  Pause deliveries on a channel

--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -212,7 +212,8 @@ public:
      *  Callback that is called when the channel was succesfully created.
      *  @param  callback    the callback to execute
      */
-    void onReady(SuccessCallback&&callback)
+    inline void onReady(const SuccessCallback& callback) { return onReady(SuccessCallback(callback)); }
+    void onReady(SuccessCallback&& callback)
     {
         // store callback
         _readyCallback = std::move(callback);
@@ -229,7 +230,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    void onError(ErrorCallback&&callback);
+    inline void onError(const ErrorCallback& callback) { return onError(ErrorCallback(callback)); }
+    void onError(ErrorCallback&& callback);
 
     /**
      *  Pause deliveries on a channel

--- a/include/amqpcpp/channelimpl.h
+++ b/include/amqpcpp/channelimpl.h
@@ -219,7 +219,7 @@ public:
         _readyCallback = std::move(callback);
 
         // direct call if channel is already ready
-        if (_state == state_ready && callback) callback();
+        if (_state == state_ready && _readyCallback) _readyCallback();
     }
 
     /**

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -243,10 +243,10 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onSuccess(const SuccessCallback &callback)
+    Deferred &onSuccess(SuccessCallback&&callback)
     {
         // store callback
-        _successCallback = callback;
+        _successCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -262,10 +262,10 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onError(const ErrorCallback &callback)
+    Deferred &onError(ErrorCallback&&callback)
     {
         // store callback
-        _errorCallback = callback;
+        _errorCallback = std::move(callback);
 
         // if the object is already in a failed state, we call the callback right away
         if (_failed) callback("Frame could not be sent");
@@ -289,13 +289,13 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onFinalize(const FinalizeCallback &callback)
+    Deferred &onFinalize(FinalizeCallback&&callback)
     {
         // if the object is already in a failed state, we call the callback right away
         if (_failed) callback();
 
         // otherwise we store callback until it's time for the call
-        else _finalizeCallback = callback;
+        else _finalizeCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -243,7 +243,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onSuccess(SuccessCallback&&callback)
+    inline Deferred &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    Deferred &onSuccess(SuccessCallback&& callback)
     {
         // store callback
         _successCallback = std::move(callback);
@@ -262,7 +263,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onError(ErrorCallback&&callback)
+    inline Deferred &onError(const ErrorCallback& callback) { return onError(ErrorCallback(callback)); }
+    Deferred &onError(ErrorCallback&& callback)
     {
         // store callback
         _errorCallback = std::move(callback);
@@ -289,7 +291,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    Deferred &onFinalize(FinalizeCallback&&callback)
+    inline Deferred &onFinalize(const FinalizeCallback& callback) { return onFinalize(FinalizeCallback(callback)); }
+    Deferred &onFinalize(FinalizeCallback&& callback)
     {
         // if the object is already in a failed state, we call the callback right away
         if (_failed) callback();

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -270,7 +270,7 @@ public:
         _errorCallback = std::move(callback);
 
         // if the object is already in a failed state, we call the callback right away
-        if (_failed) callback("Frame could not be sent");
+        if (_failed) _errorCallback("Frame could not be sent");
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredcancel.h
+++ b/include/amqpcpp/deferredcancel.h
@@ -74,7 +74,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredCancel &onSuccess(CancelCallback&&callback)
+    inline DeferredCancel &onSuccess(const CancelCallback& callback) { return onSuccess(CancelCallback(callback)); }
+    DeferredCancel &onSuccess(CancelCallback&& callback)
     {
         // store callback
         _cancelCallback = std::move(callback);
@@ -87,7 +88,8 @@ public:
      *  Register the function that is called when the cancel operation succeeded
      *  @param  callback
      */
-    DeferredCancel &onSuccess(SuccessCallback&&callback)
+    inline DeferredCancel &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    DeferredCancel &onSuccess(SuccessCallback&& callback)
     {
         // call base
         Deferred::onSuccess(std::move(callback));

--- a/include/amqpcpp/deferredcancel.h
+++ b/include/amqpcpp/deferredcancel.h
@@ -74,10 +74,10 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredCancel &onSuccess(const CancelCallback &callback)
+    DeferredCancel &onSuccess(CancelCallback&&callback)
     {
         // store callback
-        _cancelCallback = callback;
+        _cancelCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -87,10 +87,10 @@ public:
      *  Register the function that is called when the cancel operation succeeded
      *  @param  callback
      */
-    DeferredCancel &onSuccess(const SuccessCallback &callback)
+    DeferredCancel &onSuccess(SuccessCallback&&callback)
     {
         // call base
-        Deferred::onSuccess(callback);
+        Deferred::onSuccess(std::move(callback));
         
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredconfirm.h
+++ b/include/amqpcpp/deferredconfirm.h
@@ -76,10 +76,10 @@ public:
      *  confirmed mode
      *  @param  callback
      */
-    DeferredConfirm &onSuccess(const SuccessCallback &callback)
+    DeferredConfirm &onSuccess(SuccessCallback&&callback)
     {
         // call base
-        Deferred::onSuccess(callback);
+        Deferred::onSuccess(std::move(callback));
 
         // allow chaining
         return *this;
@@ -89,10 +89,10 @@ public:
      *  Callback that is called when the broker confirmed message publication
      *  @param  callback    the callback to execute
      */
-    DeferredConfirm &onAck(const AckCallback &callback)
+    DeferredConfirm &onAck(AckCallback&&callback)
     {
         // store callback
-        _ackCallback = callback;
+        _ackCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -102,10 +102,10 @@ public:
      *  Callback that is called when the broker denied message publication
      *  @param  callback    the callback to execute
      */
-    DeferredConfirm &onNack(const NackCallback &callback)
+    DeferredConfirm &onNack(NackCallback&&callback)
     {
         // store callback
-        _nackCallback = callback;
+        _nackCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredconfirm.h
+++ b/include/amqpcpp/deferredconfirm.h
@@ -76,7 +76,8 @@ public:
      *  confirmed mode
      *  @param  callback
      */
-    DeferredConfirm &onSuccess(SuccessCallback&&callback)
+    inline DeferredConfirm &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    DeferredConfirm &onSuccess(SuccessCallback&& callback)
     {
         // call base
         Deferred::onSuccess(std::move(callback));
@@ -89,7 +90,8 @@ public:
      *  Callback that is called when the broker confirmed message publication
      *  @param  callback    the callback to execute
      */
-    DeferredConfirm &onAck(AckCallback&&callback)
+    inline DeferredConfirm &onAck(const AckCallback& callback) { return onAck(AckCallback(callback)); }
+    DeferredConfirm &onAck(AckCallback&& callback)
     {
         // store callback
         _ackCallback = std::move(callback);
@@ -102,7 +104,8 @@ public:
      *  Callback that is called when the broker denied message publication
      *  @param  callback    the callback to execute
      */
-    DeferredConfirm &onNack(NackCallback&&callback)
+    inline DeferredConfirm &onNack(const NackCallback& callback) { return onNack(NackCallback(callback)); }
+    DeferredConfirm &onNack(NackCallback&& callback)
     {
         // store callback
         _nackCallback = std::move(callback);

--- a/include/amqpcpp/deferredconsumer.h
+++ b/include/amqpcpp/deferredconsumer.h
@@ -87,7 +87,8 @@ public:
      *  that you need to later stop the consumer
      *  @param  callback
      */
-    DeferredConsumer &onSuccess(ConsumeCallback&&callback)
+    inline DeferredConsumer &onSuccess(const ConsumeCallback& callback) { return onSuccess(ConsumeCallback(callback)); }
+    DeferredConsumer &onSuccess(ConsumeCallback&& callback)
     {
         // store the callback
         _consumeCallback = std::move(callback);
@@ -102,7 +103,8 @@ public:
      *  since that will also pass the consumer-tag as parameter.
      *  @param  callback
      */
-    DeferredConsumer &onSuccess(SuccessCallback&&callback)
+    inline DeferredConsumer &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    DeferredConsumer &onSuccess(SuccessCallback&& callback)
     {
         // call base
         Deferred::onSuccess(std::move(std::move(callback)));
@@ -115,7 +117,8 @@ public:
      *  Register a function to be called when a full message is received
      *  @param  callback    the callback to execute
      */
-    DeferredConsumer &onReceived(MessageCallback&&callback)
+    inline DeferredConsumer &onReceived(const MessageCallback& callback) { return onReceived(MessageCallback(callback)); }
+    DeferredConsumer &onReceived(MessageCallback&& callback)
     {
         // store callback
         _messageCallback = std::move(callback);
@@ -128,7 +131,8 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredConsumer &onMessage(MessageCallback&&callback)
+    inline DeferredConsumer &onMessage(const MessageCallback& callback) { return onMessage(MessageCallback(callback)); }
+    DeferredConsumer &onMessage(MessageCallback&& callback)
     {
         // store callback
         _messageCallback = std::move(callback);
@@ -166,7 +170,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onBegin(StartCallback&&callback)
+    inline DeferredConsumer &onBegin(const StartCallback& callback) { return onBegin(StartCallback(callback)); }
+    DeferredConsumer &onBegin(StartCallback&& callback)
     {
         // store callback
         _startCallback = std::move(callback);
@@ -182,7 +187,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onStart(StartCallback&&callback)
+    inline DeferredConsumer &onStart(const StartCallback& callback) { return onStart(StartCallback(callback)); }
+    DeferredConsumer &onStart(StartCallback&& callback)
     {
         // store callback
         _startCallback = std::move(callback);
@@ -197,7 +203,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredConsumer &onSize(SizeCallback&&callback)
+    inline DeferredConsumer &onSize(const SizeCallback& callback) { return onSize(SizeCallback(callback)); }
+    DeferredConsumer &onSize(SizeCallback&& callback)
     {
         // store callback
         _sizeCallback = std::move(callback);
@@ -212,7 +219,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredConsumer &onHeaders(HeaderCallback&&callback)
+    inline DeferredConsumer &onHeaders(const HeaderCallback& callback) { return onHeaders(HeaderCallback(callback)); }
+    DeferredConsumer &onHeaders(HeaderCallback&& callback)
     {
         // store callback
         _headerCallback = std::move(callback);
@@ -234,7 +242,8 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredConsumer &onData(DataCallback&&callback)
+    inline DeferredConsumer &onData(const DataCallback& callback) { return onData(DataCallback(callback)); }
+    DeferredConsumer &onData(DataCallback&& callback)
     {
         // store callback
         _dataCallback = std::move(callback);
@@ -249,7 +258,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onComplete(DeliveredCallback&&callback)
+    inline DeferredConsumer &onComplete(const DeliveredCallback& callback) { return onComplete(DeliveredCallback(callback)); }
+    DeferredConsumer &onComplete(DeliveredCallback&& callback)
     {
         // store callback
         _deliveredCallback = std::move(callback);
@@ -264,7 +274,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onDelivered(DeliveredCallback&&callback)
+    inline DeferredConsumer &onDelivered(const DeliveredCallback& callback) { return onDelivered(DeliveredCallback(callback)); }
+    DeferredConsumer &onDelivered(DeliveredCallback&& callback)
     {
         // store callback
         _deliveredCallback = std::move(callback);

--- a/include/amqpcpp/deferredconsumer.h
+++ b/include/amqpcpp/deferredconsumer.h
@@ -87,10 +87,10 @@ public:
      *  that you need to later stop the consumer
      *  @param  callback
      */
-    DeferredConsumer &onSuccess(const ConsumeCallback &callback)
+    DeferredConsumer &onSuccess(ConsumeCallback&&callback)
     {
         // store the callback
-        _consumeCallback = callback;
+        _consumeCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -102,10 +102,10 @@ public:
      *  since that will also pass the consumer-tag as parameter.
      *  @param  callback
      */
-    DeferredConsumer &onSuccess(const SuccessCallback &callback)
+    DeferredConsumer &onSuccess(SuccessCallback&&callback)
     {
         // call base
-        Deferred::onSuccess(callback);
+        Deferred::onSuccess(std::move(std::move(callback)));
 
         // allow chaining
         return *this;
@@ -115,10 +115,10 @@ public:
      *  Register a function to be called when a full message is received
      *  @param  callback    the callback to execute
      */
-    DeferredConsumer &onReceived(const MessageCallback &callback)
+    DeferredConsumer &onReceived(MessageCallback&&callback)
     {
         // store callback
-        _messageCallback = callback;
+        _messageCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -128,10 +128,10 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredConsumer &onMessage(const MessageCallback &callback)
+    DeferredConsumer &onMessage(MessageCallback&&callback)
     {
         // store callback
-        _messageCallback = callback;
+        _messageCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -166,10 +166,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onBegin(const StartCallback &callback)
+    DeferredConsumer &onBegin(StartCallback&&callback)
     {
         // store callback
-        _startCallback = callback;
+        _startCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -182,10 +182,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onStart(const StartCallback &callback)
+    DeferredConsumer &onStart(StartCallback&&callback)
     {
         // store callback
-        _startCallback = callback;
+        _startCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -197,10 +197,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredConsumer &onSize(const SizeCallback &callback)
+    DeferredConsumer &onSize(SizeCallback&&callback)
     {
         // store callback
-        _sizeCallback = callback;
+        _sizeCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -212,10 +212,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredConsumer &onHeaders(const HeaderCallback &callback)
+    DeferredConsumer &onHeaders(HeaderCallback&&callback)
     {
         // store callback
-        _headerCallback = callback;
+        _headerCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -234,10 +234,10 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredConsumer &onData(const DataCallback &callback)
+    DeferredConsumer &onData(DataCallback&&callback)
     {
         // store callback
-        _dataCallback = callback;
+        _dataCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -249,10 +249,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onComplete(const DeliveredCallback &callback)
+    DeferredConsumer &onComplete(DeliveredCallback&&callback)
     {
         // store callback
-        _deliveredCallback = callback;
+        _deliveredCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -264,10 +264,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredConsumer &onDelivered(const DeliveredCallback &callback)
+    DeferredConsumer &onDelivered(DeliveredCallback&&callback)
     {
         // store callback
-        _deliveredCallback = callback;
+        _deliveredCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferreddelete.h
+++ b/include/amqpcpp/deferreddelete.h
@@ -76,7 +76,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredDelete &onSuccess(DeleteCallback&&callback)
+    inline DeferredDelete &onSuccess(const DeleteCallback& callback) { return onSuccess(DeleteCallback(callback)); }
+    DeferredDelete &onSuccess(DeleteCallback&& callback)
     {
         // store callback
         _deleteCallback = std::move(callback);
@@ -89,7 +90,8 @@ public:
      *  Register the function that is called when the queue is deleted or purged
      *  @param  callback
      */
-    DeferredDelete &onSuccess(SuccessCallback&&callback)
+    inline DeferredDelete &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    DeferredDelete &onSuccess(SuccessCallback&& callback)
     {
         // call base
         Deferred::onSuccess(std::move(callback));

--- a/include/amqpcpp/deferreddelete.h
+++ b/include/amqpcpp/deferreddelete.h
@@ -76,10 +76,10 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredDelete &onSuccess(const DeleteCallback &callback)
+    DeferredDelete &onSuccess(DeleteCallback&&callback)
     {
         // store callback
-        _deleteCallback = callback;
+        _deleteCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -89,10 +89,10 @@ public:
      *  Register the function that is called when the queue is deleted or purged
      *  @param  callback
      */
-    DeferredDelete &onSuccess(const SuccessCallback &callback)
+    DeferredDelete &onSuccess(SuccessCallback&&callback)
     {
         // call base
-        Deferred::onSuccess(callback);
+        Deferred::onSuccess(std::move(callback));
         
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredget.h
+++ b/include/amqpcpp/deferredget.h
@@ -95,10 +95,10 @@ public:
      *  This fuction is also available as onReceived() and onMessage() because I always forget which name I gave to it
      *  @param  callback
      */
-    DeferredGet &onSuccess(const MessageCallback &callback)
+    DeferredGet &onSuccess(MessageCallback&&callback)
     {
         // store the callback
-        _messageCallback = callback;
+        _messageCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -108,10 +108,10 @@ public:
      *  Register a function to be called when an error occurs. This should be defined, otherwise the base methods are used.
      *  @param  callback
      */
-    DeferredGet &onError(const ErrorCallback &callback)
+    DeferredGet &onError(ErrorCallback&&callback)
     {
         // store the callback
-        _errorCallback = callback;
+        _errorCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -122,10 +122,10 @@ public:
      *  This fuction is also available as onSuccess() and onMessage() because I always forget which name I gave to it
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onReceived(const MessageCallback &callback)
+    DeferredGet &onReceived(MessageCallback&&callback)
     {
         // store callback
-        _messageCallback = callback;
+        _messageCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -136,10 +136,10 @@ public:
      *  This fuction is also available as onSuccess() and onReceived() because I always forget which name I gave to it
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onMessage(const MessageCallback &callback)
+    DeferredGet &onMessage(MessageCallback&&callback)
     {
         // store callback
-        _messageCallback = callback;
+        _messageCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -149,10 +149,10 @@ public:
      *  Register a function to be called if no message could be fetched
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onEmpty(const EmptyCallback &callback)
+    DeferredGet &onEmpty(EmptyCallback&&callback)
     {
         // store callback
-        _emptyCallback = callback;
+        _emptyCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -162,10 +162,10 @@ public:
      *  Register a function to be called when queue size information is known
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onCount(const CountCallback &callback)
+    DeferredGet &onCount(CountCallback&&callback)
     {
         // store callback
-        _countCallback = callback;
+        _countCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -177,10 +177,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onBegin(const StartCallback &callback)
+    DeferredGet &onBegin(StartCallback&&callback)
     {
         // store callback
-        _startCallback = callback;
+        _startCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -192,10 +192,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onStart(const StartCallback &callback)
+    DeferredGet &onStart(StartCallback&&callback)
     {
         // store callback
-        _startCallback = callback;
+        _startCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -207,10 +207,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredGet &onSize(const SizeCallback &callback)
+    DeferredGet &onSize(SizeCallback&&callback)
     {
         // store callback
-        _sizeCallback = callback;
+        _sizeCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -222,10 +222,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredGet &onHeaders(const HeaderCallback &callback)
+    DeferredGet &onHeaders(HeaderCallback&&callback)
     {
         // store callback
-        _headerCallback = callback;
+        _headerCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -244,10 +244,10 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredGet &onData(const DataCallback &callback)
+    DeferredGet &onData(DataCallback&&callback)
     {
         // store callback
-        _dataCallback = callback;
+        _dataCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -259,10 +259,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onComplete(const DeliveredCallback &callback)
+    DeferredGet &onComplete(DeliveredCallback&&callback)
     {
         // store callback
-        _deliveredCallback = callback;
+        _deliveredCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -274,10 +274,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onDelivered(const DeliveredCallback &callback)
+    DeferredGet &onDelivered(DeliveredCallback&&callback)
     {
         // store callback
-        _deliveredCallback = callback;
+        _deliveredCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredget.h
+++ b/include/amqpcpp/deferredget.h
@@ -95,7 +95,8 @@ public:
      *  This fuction is also available as onReceived() and onMessage() because I always forget which name I gave to it
      *  @param  callback
      */
-    DeferredGet &onSuccess(MessageCallback&&callback)
+    inline DeferredGet &onSuccess(const MessageCallback& callback) { return onSuccess(MessageCallback(callback)); }
+    DeferredGet &onSuccess(MessageCallback&& callback)
     {
         // store the callback
         _messageCallback = std::move(callback);
@@ -108,7 +109,8 @@ public:
      *  Register a function to be called when an error occurs. This should be defined, otherwise the base methods are used.
      *  @param  callback
      */
-    DeferredGet &onError(ErrorCallback&&callback)
+    inline DeferredGet &onError(const ErrorCallback& callback) { return onError(ErrorCallback(callback)); }
+    DeferredGet &onError(ErrorCallback&& callback)
     {
         // store the callback
         _errorCallback = std::move(callback);
@@ -122,7 +124,8 @@ public:
      *  This fuction is also available as onSuccess() and onMessage() because I always forget which name I gave to it
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onReceived(MessageCallback&&callback)
+    inline DeferredGet &onReceived(const MessageCallback& callback) { return onReceived(MessageCallback(callback)); }
+    DeferredGet &onReceived(MessageCallback&& callback)
     {
         // store callback
         _messageCallback = std::move(callback);
@@ -136,7 +139,8 @@ public:
      *  This fuction is also available as onSuccess() and onReceived() because I always forget which name I gave to it
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onMessage(MessageCallback&&callback)
+    inline DeferredGet &onMessage(const MessageCallback& callback) { return onMessage(MessageCallback(callback)); }
+    DeferredGet &onMessage(MessageCallback&& callback)
     {
         // store callback
         _messageCallback = std::move(callback);
@@ -149,7 +153,8 @@ public:
      *  Register a function to be called if no message could be fetched
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onEmpty(EmptyCallback&&callback)
+    inline DeferredGet &onEmpty(const EmptyCallback& callback) { return onEmpty(EmptyCallback(callback)); }
+    DeferredGet &onEmpty(EmptyCallback&& callback)
     {
         // store callback
         _emptyCallback = std::move(callback);
@@ -162,7 +167,8 @@ public:
      *  Register a function to be called when queue size information is known
      *  @param  callback    the callback to execute
      */
-    DeferredGet &onCount(CountCallback&&callback)
+    inline DeferredGet &onCount(const CountCallback& callback) { return onCount(CountCallback(callback)); }
+    DeferredGet &onCount(CountCallback&& callback)
     {
         // store callback
         _countCallback = std::move(callback);
@@ -177,7 +183,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onBegin(StartCallback&&callback)
+    inline DeferredGet &onBegin(const StartCallback& callback) { return onBegin(StartCallback(callback)); }
+    DeferredGet &onBegin(StartCallback&& callback)
     {
         // store callback
         _startCallback = std::move(callback);
@@ -192,7 +199,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onStart(StartCallback&&callback)
+    inline DeferredGet &onStart(const StartCallback& callback) { return onStart(StartCallback(callback)); }
+    DeferredGet &onStart(StartCallback&& callback)
     {
         // store callback
         _startCallback = std::move(callback);
@@ -207,7 +215,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredGet &onSize(SizeCallback&&callback)
+    inline DeferredGet &onSize(const SizeCallback& callback) { return onSize(SizeCallback(callback)); }
+    DeferredGet &onSize(SizeCallback&& callback)
     {
         // store callback
         _sizeCallback = std::move(callback);
@@ -222,7 +231,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredGet &onHeaders(HeaderCallback&&callback)
+    inline DeferredGet &onHeaders(const HeaderCallback& callback) { return onHeaders(HeaderCallback(callback)); }
+    DeferredGet &onHeaders(HeaderCallback&& callback)
     {
         // store callback
         _headerCallback = std::move(callback);
@@ -244,7 +254,8 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredGet &onData(DataCallback&&callback)
+    inline DeferredGet &onData(const DataCallback& callback) { return onData(DataCallback(callback)); }
+    DeferredGet &onData(DataCallback&& callback)
     {
         // store callback
         _dataCallback = std::move(callback);
@@ -259,7 +270,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onComplete(DeliveredCallback&&callback)
+    inline DeferredGet &onComplete(const DeliveredCallback& callback) { return onComplete(DeliveredCallback(callback)); }
+    DeferredGet &onComplete(DeliveredCallback&& callback)
     {
         // store callback
         _deliveredCallback = std::move(callback);
@@ -274,7 +286,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredGet &onDelivered(DeliveredCallback&&callback)
+    inline DeferredGet &onDelivered(const DeliveredCallback& callback) { return onDelivered(DeliveredCallback(callback)); }
+    DeferredGet &onDelivered(DeliveredCallback&& callback)
     {
         // store callback
         _deliveredCallback = std::move(callback);

--- a/include/amqpcpp/deferredpublish.h
+++ b/include/amqpcpp/deferredpublish.h
@@ -104,7 +104,8 @@ public:
      *  Callback that is called when the broker confirmed message publication
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onAck(PublishAckCallback&&callback)
+    inline DeferredPublish &onAck(const PublishAckCallback& callback) { return onAck(PublishAckCallback(callback)); }
+    DeferredPublish &onAck(PublishAckCallback&& callback)
     {
         // store callback
         _ackCallback = std::move(callback);
@@ -117,7 +118,8 @@ public:
      *  Callback that is called when the broker denied message publication
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onNack(PublishNackCallback&&callback)
+    inline DeferredPublish &onNack(const PublishNackCallback& callback) { return onNack(PublishNackCallback(callback)); }
+    DeferredPublish &onNack(PublishNackCallback&& callback)
     {
         // store callback
         _nackCallback = std::move(callback);
@@ -131,7 +133,8 @@ public:
      *  rejecting it or because of a channel error
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onLost(PublishLostCallback&&callback)
+    inline DeferredPublish &onLost(const PublishLostCallback& callback) { return onLost(PublishLostCallback(callback)); }
+    DeferredPublish &onLost(PublishLostCallback&& callback)
     {
         // store callback
         _lostCallback = std::move(callback);

--- a/include/amqpcpp/deferredpublish.h
+++ b/include/amqpcpp/deferredpublish.h
@@ -104,10 +104,10 @@ public:
      *  Callback that is called when the broker confirmed message publication
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onAck(const PublishAckCallback &callback)
+    DeferredPublish &onAck(PublishAckCallback&&callback)
     {
         // store callback
-        _ackCallback = callback;
+        _ackCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -117,10 +117,10 @@ public:
      *  Callback that is called when the broker denied message publication
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onNack(const PublishNackCallback &callback)
+    DeferredPublish &onNack(PublishNackCallback&&callback)
     {
         // store callback
-        _nackCallback = callback;
+        _nackCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -131,10 +131,10 @@ public:
      *  rejecting it or because of a channel error
      *  @param  callback    the callback to execute
      */
-    DeferredPublish &onLost(const PublishLostCallback &callback)
+    DeferredPublish &onLost(PublishLostCallback&&callback)
     {
         // store callback
-        _lostCallback = callback;
+        _lostCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredqueue.h
+++ b/include/amqpcpp/deferredqueue.h
@@ -76,10 +76,10 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredQueue &onSuccess(const QueueCallback &callback)
+    DeferredQueue &onSuccess(QueueCallback&&callback)
     {
         // store callback
-        _queueCallback = callback;
+        _queueCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -89,10 +89,10 @@ public:
      *  Register the function that is called when the queue is declared
      *  @param  callback
      */
-    DeferredQueue &onSuccess(const SuccessCallback &callback)
+    DeferredQueue &onSuccess(SuccessCallback&&callback)
     {
         // call base
-        Deferred::onSuccess(callback);
+        Deferred::onSuccess(std::move(callback));
         
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredqueue.h
+++ b/include/amqpcpp/deferredqueue.h
@@ -76,7 +76,8 @@ public:
      *
      *  @param  callback    the callback to execute
      */
-    DeferredQueue &onSuccess(QueueCallback&&callback)
+    inline DeferredQueue &onSuccess(const QueueCallback& callback) { return onSuccess(QueueCallback(callback)); }
+    DeferredQueue &onSuccess(QueueCallback&& callback)
     {
         // store callback
         _queueCallback = std::move(callback);
@@ -89,7 +90,8 @@ public:
      *  Register the function that is called when the queue is declared
      *  @param  callback
      */
-    DeferredQueue &onSuccess(SuccessCallback&&callback)
+    inline DeferredQueue &onSuccess(const SuccessCallback& callback) { return onSuccess(SuccessCallback(callback)); }
+    DeferredQueue &onSuccess(SuccessCallback&& callback)
     {
         // call base
         Deferred::onSuccess(std::move(callback));

--- a/include/amqpcpp/deferredrecall.h
+++ b/include/amqpcpp/deferredrecall.h
@@ -101,10 +101,10 @@ public:
      *  Register a function to be called when a full message is returned
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onReceived(const BounceCallback &callback)
+    DeferredRecall &onReceived(BounceCallback&&callback)
     {
         // store callback
-        _bounceCallback = callback;
+        _bounceCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -114,10 +114,10 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onMessage(const BounceCallback &callback)
+    DeferredRecall &onMessage(BounceCallback&&callback)
     {
         // store callback
-        _bounceCallback = callback;
+        _bounceCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -127,10 +127,10 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onReturned(const BounceCallback &callback)
+    DeferredRecall &onReturned(BounceCallback&&callback)
     {
         // store callback
-        _bounceCallback = callback;
+        _bounceCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -140,10 +140,10 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onBounced(const BounceCallback &callback)
+    DeferredRecall &onBounced(BounceCallback&&callback)
     {
         // store callback
-        _bounceCallback = callback;
+        _bounceCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -156,10 +156,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredRecall &onBegin(const ReturnCallback &callback)
+    DeferredRecall &onBegin(ReturnCallback&&callback)
     {
         // store callback
-        _beginCallback = callback;
+        _beginCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -171,10 +171,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredRecall &onSize(const SizeCallback &callback)
+    DeferredRecall &onSize(SizeCallback&&callback)
     {
         // store callback
-        _sizeCallback = callback;
+        _sizeCallback = std::move(callback);
         
         // allow chaining
         return *this;
@@ -186,10 +186,10 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredRecall &onHeaders(const HeaderCallback &callback)
+    DeferredRecall &onHeaders(HeaderCallback&&callback)
     {
         // store callback
-        _headerCallback = callback;
+        _headerCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -208,10 +208,10 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredRecall &onData(const DataCallback &callback)
+    DeferredRecall &onData(DataCallback&&callback)
     {
         // store callback
-        _dataCallback = callback;
+        _dataCallback = std::move(callback);
 
         // allow chaining
         return *this;
@@ -223,10 +223,10 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredRecall &onComplete(const ReturnedCallback &callback)
+    DeferredRecall &onComplete(ReturnedCallback&&callback)
     {
         // store callback
-        _completeCallback = callback;
+        _completeCallback = std::move(callback);
 
         // allow chaining
         return *this;

--- a/include/amqpcpp/deferredrecall.h
+++ b/include/amqpcpp/deferredrecall.h
@@ -101,7 +101,8 @@ public:
      *  Register a function to be called when a full message is returned
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onReceived(BounceCallback&&callback)
+    inline DeferredRecall &onReceived(const BounceCallback& callback) { return onReceived(BounceCallback(callback)); }
+    DeferredRecall &onReceived(BounceCallback&& callback)
     {
         // store callback
         _bounceCallback = std::move(callback);
@@ -114,7 +115,8 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onMessage(BounceCallback&&callback)
+    inline DeferredRecall &onMessage(const BounceCallback& callback) { return onMessage(BounceCallback(callback)); }
+    DeferredRecall &onMessage(BounceCallback&& callback)
     {
         // store callback
         _bounceCallback = std::move(callback);
@@ -127,7 +129,8 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onReturned(BounceCallback&&callback)
+    inline DeferredRecall &onReturned(const BounceCallback& callback) { return onReturned(BounceCallback(callback)); }
+    DeferredRecall &onReturned(BounceCallback&& callback)
     {
         // store callback
         _bounceCallback = std::move(callback);
@@ -140,7 +143,8 @@ public:
      *  Alias for onReceived() (see above)
      *  @param  callback    the callback to execute
      */
-    DeferredRecall &onBounced(BounceCallback&&callback)
+    inline DeferredRecall &onBounced(const BounceCallback& callback) { return onBounced(BounceCallback(callback)); }
+    DeferredRecall &onBounced(BounceCallback&& callback)
     {
         // store callback
         _bounceCallback = std::move(callback);
@@ -156,7 +160,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredRecall &onBegin(ReturnCallback&&callback)
+    inline DeferredRecall &onBegin(const ReturnCallback& callback) { return onBegin(ReturnCallback(callback)); }
+    DeferredRecall &onBegin(ReturnCallback&& callback)
     {
         // store callback
         _beginCallback = std::move(callback);
@@ -171,7 +176,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredRecall &onSize(SizeCallback&&callback)
+    inline DeferredRecall &onSize(const SizeCallback& callback) { return onSize(SizeCallback(callback)); }
+    DeferredRecall &onSize(SizeCallback&& callback)
     {
         // store callback
         _sizeCallback = std::move(callback);
@@ -186,7 +192,8 @@ public:
      *  @param  callback    The callback to invoke for message headers
      *  @return Same object for chaining
      */
-    DeferredRecall &onHeaders(HeaderCallback&&callback)
+    inline DeferredRecall &onHeaders(const HeaderCallback& callback) { return onHeaders(HeaderCallback(callback)); }
+    DeferredRecall &onHeaders(HeaderCallback&& callback)
     {
         // store callback
         _headerCallback = std::move(callback);
@@ -208,7 +215,8 @@ public:
      *  @param  callback    The callback to invoke for chunks of message data
      *  @return Same object for chaining
      */
-    DeferredRecall &onData(DataCallback&&callback)
+    inline DeferredRecall &onData(const DataCallback& callback) { return onData(DataCallback(callback)); }
+    DeferredRecall &onData(DataCallback&& callback)
     {
         // store callback
         _dataCallback = std::move(callback);
@@ -223,7 +231,8 @@ public:
      *  @param  callback    The callback to invoke
      *  @return Same object for chaining
      */
-    DeferredRecall &onComplete(ReturnedCallback&&callback)
+    inline DeferredRecall &onComplete(const ReturnedCallback& callback) { return onComplete(ReturnedCallback(callback)); }
+    DeferredRecall &onComplete(ReturnedCallback&& callback)
     {
         // store callback
         _completeCallback = std::move(callback);

--- a/include/amqpcpp/tagger.h
+++ b/include/amqpcpp/tagger.h
@@ -136,7 +136,8 @@ public:
      *  Install an error callback
      *  @param  callback
      */
-    void onError(ErrorCallback&&callback);
+    inline void onError(const ErrorCallback& callback) { return onError(ErrorCallback(callback)); }
+    void onError(ErrorCallback&& callback);
 };
 
 /**

--- a/include/amqpcpp/tagger.h
+++ b/include/amqpcpp/tagger.h
@@ -136,7 +136,7 @@ public:
      *  Install an error callback
      *  @param  callback
      */
-    void onError(const ErrorCallback &callback);
+    void onError(ErrorCallback&&callback);
 };
 
 /**

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -65,7 +65,7 @@ ChannelImpl::~ChannelImpl()
  *
  *  @param  callback    the callback to execute
  */
-void ChannelImpl::onError(ErrorCallback&&callback)
+void ChannelImpl::onError(ErrorCallback&& callback)
 {
     // store callback
     _errorCallback = std::move(callback);

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -65,10 +65,10 @@ ChannelImpl::~ChannelImpl()
  *
  *  @param  callback    the callback to execute
  */
-void ChannelImpl::onError(const ErrorCallback &callback)
+void ChannelImpl::onError(ErrorCallback&&callback)
 {
     // store callback
-    _errorCallback = callback;
+    _errorCallback = std::move(callback);
 
     // if the channel is usable, all is ok
     if (usable()) return;

--- a/src/channelimpl.cpp
+++ b/src/channelimpl.cpp
@@ -74,25 +74,25 @@ void ChannelImpl::onError(ErrorCallback&& callback)
     if (usable()) return;
 
     // validity check
-    if (!callback) return;
+    if (!_errorCallback) return;
 
     // is the channel closing down?
-    if (_state == state_closing) return callback("Channel is closing down");
+    if (_state == state_closing) return _errorCallback("Channel is closing down");
 
     // the channel is closed, but what is the connection doing?
-    if (_connection == nullptr) return callback("Channel is not linked to a connection");
+    if (_connection == nullptr) return _errorCallback("Channel is not linked to a connection");
     
     // if the connection is valid, this is a pure channel error
-    if (_connection->ready()) return callback("Channel is in an error state, but the connection is valid");
+    if (_connection->ready()) return _errorCallback("Channel is in an error state, but the connection is valid");
 
     // the connection is closing down
-    if (_connection->closing()) return callback("Channel is in an error state, the AMQP connection is closing down");
+    if (_connection->closing()) return _errorCallback("Channel is in an error state, the AMQP connection is closing down");
 
     // the connection is already closed
-    if (_connection->closed()) return callback("Channel is in an error state, the AMQP connection has been closed");
+    if (_connection->closed()) return _errorCallback("Channel is in an error state, the AMQP connection has been closed");
    
     // direct call if channel is already in error state
-    callback("Channel is in error state, something went wrong with the AMQP connection");
+    _errorCallback("Channel is in error state, something went wrong with the AMQP connection");
 }
 
 /**

--- a/src/tagger.cpp
+++ b/src/tagger.cpp
@@ -182,10 +182,10 @@ Deferred &Tagger::close()
  *  Install an error callback
  *  @param  callback
  */
-void Tagger::onError(const ErrorCallback &callback)
+void Tagger::onError(ErrorCallback&&callback)
 {
     // we store the callback
-    _errorCallback = callback;
+    _errorCallback = std::move(callback);
 
     // check the callback
     if (!callback) return;

--- a/src/tagger.cpp
+++ b/src/tagger.cpp
@@ -188,13 +188,13 @@ void Tagger::onError(ErrorCallback&& callback)
     _errorCallback = std::move(callback);
 
     // check the callback
-    if (!callback) return;
+    if (!_errorCallback) return;
 
     // if the channel is no longer usable, report that
-    if (!_implementation->usable()) return callback("Channel is no longer usable");
+    if (!_implementation->usable()) return _errorCallback("Channel is no longer usable");
 
     // specify that we're already closing
-    if (_close) callback("Wrapped channel is closing down");
+    if (_close) _errorCallback("Wrapped channel is closing down");
 }
 
 /**

--- a/src/tagger.cpp
+++ b/src/tagger.cpp
@@ -182,7 +182,7 @@ Deferred &Tagger::close()
  *  Install an error callback
  *  @param  callback
  */
-void Tagger::onError(ErrorCallback&&callback)
+void Tagger::onError(ErrorCallback&& callback)
 {
     // we store the callback
     _errorCallback = std::move(callback);


### PR DESCRIPTION
This PR changes the signature of all functions accepting a callback to take an rvalue reference instead of a const lvalue reference.

Example:
```c++
void onReady(const SuccessCallback &callback)
```
becomes
```c++
inline void onReady(const SuccessCallback& callback) { onReady(SuccessCallback(callback)); }
void onReady(SuccessCallback&& callback)
```

Within the function body, the callback is moved into place. This avoids making a copy of the callback, which may be expensive if it has a large closure type (all wrapped in a `std::function`).

This method of passing arguments is discussed e.g. [here](https://www.codesynthesis.com/~boris/blog/2012/06/26/efficient-argument-passing-cxx11-part2/).