### PR TITLE
Allow user to pass a pre-configured SSL_CTX to the client.

### DIFF
--- a/include/amqpcpp/linux_tcp/tcpconnection.h
+++ b/include/amqpcpp/linux_tcp/tcpconnection.h
@@ -128,6 +128,17 @@ private:
     }
     
     /**
+     *  Method that is called to get a user-provided SSL context
+     *  @param  state
+     *  @return SSL_CTX*
+     */
+    virtual SSL_CTX *onSecuring(TcpState *state) override
+    {
+        // pass on to user-space
+        if (_handler) return _handler->onSecuring(this);
+    }
+
+    /**
      *  Method that is called when right before connection is being secured
      *  @param  state
      *  @param  ssl
@@ -205,7 +216,7 @@ public:
      *  @param  handler         User implemented handler object
      *  @param  hostname        The address to connect to
      */
-    TcpConnection(TcpHandler *handler, const Address &address, SSL_CTX *ctx = nullptr);
+    TcpConnection(TcpHandler *handler, const Address &address);
     
     /**
      *  No copying

--- a/include/amqpcpp/linux_tcp/tcphandler.h
+++ b/include/amqpcpp/linux_tcp/tcphandler.h
@@ -62,6 +62,20 @@ public:
     /**
      *  Method that is called after a TCP connection has been set up, and right before
      *  the SSL handshake is going to be performed to secure the connection (only for
+     *  amqps:// connections). If a user space implementation returns a pointer to an
+     *  existing OpenSSL SSL_CTX here, that context will be used to create new SSL
+     *  sessions from. Otherwise, if nullptr is returned, a default SSL_CTX is created.
+     *  @param  connection  The TCP connection
+     *  @return SSL_CTX *   A user-provided, pre-configured SSL_CTX, will not be freed.
+     */
+    virtual SSL_CTX *onSecuring(TcpConnection *connection)
+    {
+        return nullptr;
+    }
+
+    /**
+     *  Method that is called after a TCP connection has been set up, and right before
+     *  the SSL handshake is going to be performed to secure the connection (only for
      *  amqps:// connections). This method can be overridden in user space to load
      *  client side certificates.
      *  @param  connection      The connection for which TLS was just started

--- a/include/amqpcpp/linux_tcp/tcpparent.h
+++ b/include/amqpcpp/linux_tcp/tcpparent.h
@@ -46,7 +46,14 @@ public:
      *  @param  state
      */
     virtual void onConnected(TcpState *state) = 0;
-    
+
+    /**
+     *  Method that is called to get a user-provided SSL context
+     *  @param  state
+     *  @return SSL_CTX*
+     */
+    virtual SSL_CTX *onSecuring(TcpState *state) = 0;
+
     /**
      *  Method that is called right before a connection is secured and that allows userspac to change SSL
      *  @param  state

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -24,9 +24,9 @@ namespace AMQP {
  *  @param  handler         User implemented handler object
  *  @param  hostname        The address to connect to
  */
-TcpConnection::TcpConnection(TcpHandler *handler, const Address &address, SSL_CTX* ctx) :
+TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
     _handler(handler),
-    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), ConnectionOrder(address.option("connectionOrder")), ctx)),
+    _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), ConnectionOrder(address.option("connectionOrder")))),
     _connection(this, address.login(), address.vhost()) 
 {
     // tell the handler

--- a/src/linux_tcp/tcpresolver.h
+++ b/src/linux_tcp/tcpresolver.h
@@ -91,11 +91,6 @@ private:
      */
     ConnectionOrder _order;
 
-    /**
-     * Preconfigured SSL_CTX to use instead of creating a new one.
-     * @var SSL_CTX
-     */
-    SSL_CTX* _ctx;
 
     /**
      *  Run the thread
@@ -216,14 +211,13 @@ public:
      *  @param  timeout     timeout per connection attempt
      *  @param  order       How should we oreder the addresses of the host to connect to
      */
-    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout, const ConnectionOrder &order, SSL_CTX* ctx) : 
+    TcpResolver(TcpParent *parent, std::string hostname, uint16_t port, bool secure, int timeout, const ConnectionOrder &order) : 
         TcpExtState(parent), 
         _hostname(std::move(hostname)),
         _secure(secure),
         _port(port),
         _timeout(timeout),
-        _order(order),
-        _ctx(ctx)
+        _order(order)
     {
         // tell the event loop to monitor the filedescriptor of the pipe
         parent->onIdle(this, _pipe.in(), readable);
@@ -272,7 +266,7 @@ public:
             if (!monitor.valid()) return nullptr;
             
             // if we need a secure connection, we move to the tls handshake (this could throw)
-            if (_secure) return new SslHandshake(this, std::move(_hostname), std::move(_buffer), _ctx);
+            if (_secure) return new SslHandshake(this, std::move(_hostname), std::move(_buffer));
             
             // otherwise we have a valid regular tcp connection
             else return new TcpConnected(this, std::move(_buffer));


### PR DESCRIPTION
When using a secure connection, the `onSecuring()` callback is invoked with a pointer to a freshly created OpenSSL `SSL` object. You can then install certificates etc. on this session object.

This session object is created from a 'template' `SSL_CTX` object, which stores the defaults for all newly created SSL sessions. Some applications might have a pre-configured `SSL_CTX` and use that for configuring the SSL connection.

This patch adds a way to pass a pre-configured `SSL_CTX` to the connection, which is used instead of the one that is constructed internally.