### PR TITLE
Allow user to provide an alternative Authentication mechanism

### DIFF
--- a/include/amqpcpp/login.h
+++ b/include/amqpcpp/login.h
@@ -78,7 +78,7 @@ public:
     }
 
     /**
-     *  Constructor
+     *  Constructor with PLAIN authentication mechanism
      *  @param  user
      *  @param  password
      */

--- a/include/amqpcpp/login.h
+++ b/include/amqpcpp/login.h
@@ -39,20 +39,43 @@ private:
      */
     std::string _password;
 
+    /**
+     *  The security mechanism
+     *  @var string
+     */
+    std::string _mechanism;
+
+    /**
+     *  The security response
+     *  @var string
+     */
+    std::string _response;
+
 
 public:
     /**
-     *  Default constructor
+     *  Default constructor with PLAIN authentication
      */
-    Login() : _user("guest"), _password("guest") {}
+    Login() : _user("guest"), _password("guest")
+    {
+        // Set default PLAIN mechanism and response
+        _mechanism = "PLAIN";
+        _response = saslPlain();
+    }
 
     /**
-     *  Constructor
+     *  Constructor with PLAIN authentication mechanism
+     *
      *  @param  user
      *  @param  password
      */
     Login(std::string user, std::string password) :
-        _user(std::move(user)), _password(std::move(password)) {}
+        _user(std::move(user)), _password(std::move(password))
+    {
+        // Set default PLAIN mechanism and response
+        _mechanism = "PLAIN";
+        _response = saslPlain();
+    }
 
     /**
      *  Constructor
@@ -60,7 +83,35 @@ public:
      *  @param  password
      */
     Login(const char *user, const char *password) :
-        _user(user), _password(password) {}
+        _user(user), _password(password)
+    {
+        // Set default PLAIN mechanism and response
+        _mechanism = "PLAIN";
+        _response = saslPlain();
+    }
+
+    /**
+     *  Constructor with custom authentication mechanism
+     *  @param  user
+     *  @param  password
+     *  @param  mechanism
+     *  @param  response
+     */
+    Login(std::string user, std::string password, std::string mechanism, std::string response)
+        : _user(std::move(user))
+        , _password(std::move(password))
+        , _mechanism(std::move(mechanism))
+        , _response(std::move(response)) {}
+
+    /**
+     *  Constructor with custom authentication mechanism
+     *  @param  user
+     *  @param  password
+     *  @param  mechanism
+     *  @param  response
+     */
+    Login(const char *user, const char *password, const char *mechanism, const char *response)
+        : _user(user), _password(password), _mechanism(mechanism), _response(response) {}
 
     /**
      *  Destructor
@@ -73,7 +124,7 @@ public:
      */
     operator bool () const
     {
-        return !_user.empty() || !_password.empty();
+        return !_user.empty() || !_password.empty() || !_mechanism.empty() || !_response.empty();
     }
     
     /**
@@ -82,7 +133,7 @@ public:
      */
     bool operator! () const
     {
-        return _user.empty() && _password.empty();
+        return _user.empty() && _password.empty() && _mechanism.empty() && _response.empty();
     }
 
     /**
@@ -104,6 +155,24 @@ public:
     }
 
     /**
+     *  Retrieve the security mechanism
+     *  @return string
+     */
+    const std::string &mechanism() const
+    {
+        return _mechanism;
+    }
+
+    /**
+     *  String representation for security response
+     *  @return string
+     */
+    const std::string &response() const
+    {
+        return _response;
+    }
+
+    /**
      *  String representation in SASL PLAIN mode
      *  @return string
      */
@@ -115,7 +184,7 @@ public:
         // append other elements
         return result.append(_user).append("\0",1).append(_password);
     }
-    
+
     /**
      *  Comparison operator
      *  @param  that
@@ -124,7 +193,10 @@ public:
     bool operator==(const Login &that) const
     {
         // username and password must match
-        return _user == that._user && _password == that._password;
+        return _user == that._user           &&
+               _password == that._password   &&
+               _mechanism == that._mechanism &&
+               _response == that._response;
     }
 
     /**
@@ -146,10 +218,13 @@ public:
     bool operator<(const Login &that) const
     {
         // compare users
-        if (_user != that._user) return _user < that._user;
-        
+        if (_user != that._user)           return _user < that._user;
         // compare passwords
-        return _password < that._password;
+        if (_password != that._password)   return _password < that._password;
+        // compare mechanisms
+        if (_mechanism != that._mechanism) return _mechanism < that._mechanism;
+        // compare responses
+        return _response < that._response;
     }
 
     /**
@@ -161,7 +236,10 @@ public:
     friend std::ostream &operator<<(std::ostream &stream, const Login &login)
     {
         // write username and password
-        return stream << login._user << ":" << login._password;
+        return stream << login._user      << ":"
+                      << login._password  << ":"
+                      << login._mechanism << ":"
+                      << login._response;
     }
 
 };

--- a/src/connectionstartframe.h
+++ b/src/connectionstartframe.h
@@ -204,7 +204,7 @@ public:
         if (!properties.contains("capabilities")) properties["capabilities"] = capabilities;
         
         // send back a connection start ok frame
-        connection->send(ConnectionStartOKFrame(properties, "PLAIN", connection->login().saslPlain(), "en_US"));
+        connection->send(ConnectionStartOKFrame(properties, connection->login().mechanism(), connection->login().response(), "en_US"));
         
         // done
         return true;


### PR DESCRIPTION
The modifications to login.h and connectionstartframe.h allow a user to optionally provide an authentication mechanism other than the default PLAIN mechanism (username and password).