### PR TITLE
Allow passing pointers to arbitrary types to Channel::publish()

### DIFF
--- a/include/amqpcpp/channel.h
+++ b/include/amqpcpp/channel.h
@@ -405,7 +405,7 @@ public:
      */
     bool publish(const std::string &exchange, const std::string &routingKey, const Envelope &envelope, int flags = 0) { return _implementation->publish(exchange, routingKey, envelope, flags); }
     bool publish(const std::string &exchange, const std::string &routingKey, const std::string &message, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message.data(), message.size()), flags); }
-    bool publish(const std::string &exchange, const std::string &routingKey, const char *message, size_t size, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message, size), flags); }
+    bool publish(const std::string &exchange, const std::string &routingKey, const void *message, size_t size, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(static_cast<const char *>(message), size), flags); }
     bool publish(const std::string &exchange, const std::string &routingKey, const char *message, int flags = 0) { return _implementation->publish(exchange, routingKey, Envelope(message, strlen(message)), flags); }
 
     /**


### PR DESCRIPTION
This PR allows to write code like this
```
void foo(AMQP::Channel & ch, someType & data)
{
    ch.publish("", "", &data, sizeof(data));
}
```
whereas before you had to explicitly cast like this
```
void foo(AMQP::Channel & ch, someType & data)
{
    ch.publish("", "", reinterpret_cast<char*>(&data), sizeof(data));
}
```
