### PR TITLE
Fix handling of messages larger than 2 GB

### DIFF
--- a/include/amqpcpp/inbuffer.h
+++ b/include/amqpcpp/inbuffer.h
@@ -47,9 +47,9 @@ protected:
 
     /**
      *  Number of bytes already processed
-     *  @var    uint32_t
+     *  @var    size_t
      */
-    uint32_t _skip = 0;
+    size_t _skip = 0;
 
 public:
     /**


### PR DESCRIPTION
While since 328d9d12de10475b4e389d0f54ca054867a3af24 `InBuffer` can accept data larger than 2 GB its internal structure did not fully support this. This PR fixes that.