### PR TITLE
make sure compilers dont complain about unused parameters

### DIFF
--- a/src/extframe.h
+++ b/src/extframe.h
@@ -150,6 +150,9 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
+        // make sure compilers dont complain about unused parameters
+        (void) connection;
+
         // this is an exception
         throw ProtocolException("unimplemented frame type " + std::to_string(type()));
 

--- a/src/methodframe.h
+++ b/src/methodframe.h
@@ -95,6 +95,9 @@ public:
      */
     virtual bool process(ConnectionImpl *connection) override
     {
+        // make sure compilers dont complain about unused parameters
+        (void) connection;
+
         // this is an exception
         throw ProtocolException("unimplemented frame type " + std::to_string(type()) + " class " + std::to_string(classID()) + " method " + std::to_string(methodID()));
     }


### PR DESCRIPTION
gcc-8.4 complains about this with `-Wunused-parameter`