### PR TITLE
Handle max-frame=0 correctly

### DIFF
--- a/src/connectionimpl.cpp
+++ b/src/connectionimpl.cpp
@@ -389,7 +389,7 @@ bool ConnectionImpl::send(const Frame &frame)
 
     // if the frame is bigger than we allow on the connection
     // it is impossible to send out this frame successfully
-    if (frame.totalSize() > _maxFrame) return false;
+    if (_maxFrame > 0 && frame.totalSize() > _maxFrame) return false;
 
     // are we still setting up the connection?
     if ((_state == state_connected && _queue.empty()) || frame.partOfHandshake())


### PR DESCRIPTION
Fixes #475.

Mirrors the equivalent check done for `_maxChannels`: https://github.com/CopernicaMarketingSoftware/AMQP-CPP/blob/c273d936253ed08ff15642d6874406a564b8f9b5/src/connectionimpl.cpp#L62