### PR TITLE
CMake: explicit link to ws2_32 if targeting Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,10 @@ else()
     add_library(${PROJECT_NAME} STATIC ${src_MAIN} ${src_LINUX_TCP})
 endif()
 
+if(WIN32)
+    target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32)
+endif()
+
 # install rules
 # ------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
`#pragma comment(lib,"Ws2_32.lib")` in `endian.h` is a hack and is not portable. It only works for Visual Studio, not gcc or clang on Windows.

closes https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/513