### PR TITLE
Bump required cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #       ON:  Build posix handler implementation
 #       OFF: Don't build posix handler implementation
 
-cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 # project name
 project(amqpcpp)


### PR DESCRIPTION
This is to conform to the requirement in cmake 4.0 that all projects must specify a minimum version of 3.5.

Fixes #540