### PR TITLE
CMakeLists.txt: link OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,4 +136,5 @@ if(AMQP-CPP_LINUX_TCP)
     # Find OpenSSL and provide include dirs
     find_package(OpenSSL REQUIRED)
     target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)
 endif()


### PR DESCRIPTION
Hello.

I created the pull request to Conan package repository and found this.
[https://github.com/conan-io/conan-center-index/pull/27450](https://github.com/conan-io/conan-center-index/pull/27450)

`
if(AMQP-CPP_LINUX_TCP)
     # Find OpenSSL and provide include dirs
     find_package(OpenSSL REQUIRED)
     target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
    target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)
 endif()
`

 + target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)