### PR TITLE
Add type 'x' in Field::decode.

### DIFF
--- a/src/field.cpp
+++ b/src/field.cpp
@@ -43,6 +43,7 @@ std::unique_ptr<Field> Field::decode(InBuffer &frame)
         case 'T':   return std::unique_ptr<Field>(new Timestamp(frame));
         case 'F':   return std::unique_ptr<Field>(new Table(frame));
         case 'V':   return std::unique_ptr<Field>(new VoidField(frame));
+        case 'x':   return std::unique_ptr<Field>(new LongString(frame));
         default:    return nullptr;
     }
 }


### PR DESCRIPTION
type 'x' means byte array (array of unsigned chars) so it is strictly not correct to return a LongString (array of signed chars). But with this change the library can continue going after receiving type 'x'. The original code crashes or starts doing undefined things when receiving a nonempty byte array from a RabbitMQ client.

See f.x. https://www.rabbitmq.com/amqp-0-9-1-errata or https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.BinaryTableValue.html for a description of type 'x'.