### PR TITLE
Refactoring libboostasio (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ to RabbitMQ has to be set up.
 
 An example compilation command for an application using the TCP module:
 ```bash
-g++ -g -Wall -lamqcpp -lpthread -ldl my-amqp-cpp.c -o my-amqp-cpp
+g++ -std=c++17 -g -Wall -lamqcpp -lpthread -ldl my-amqp-cpp.c -o my-amqp-cpp
 ```
 
 HOW TO USE AMQP-CPP
@@ -710,7 +710,7 @@ it has a couple of open issues.
 
 | TCP Handler Impl        | Header File Location   |  Sample File Location     |
 | ----------------------- | ---------------------- | ------------------------- |
-| Boost asio (io_service) | include/libboostasio.h | examples/libboostasio.cpp |  
+| Boost asio              | include/libboostasio.h | examples/libboostasio.cpp |
 | libev                   | include/libev.h        | examples/libev.cpp        |
 | libevent                | include/libevent.h     | examples/libevent.cpp     |
 | libuv                   | include/libuv.h        | examples/libuv.cpp        |
@@ -770,7 +770,7 @@ class MyTcpHandler : public AMQP::TcpHandler
 ````
 
 If you enable heartbeats, it is your own responsibility to ensure that the
-```connection->heartbeat()``` method is called at least once during this period,
+`connection->heartbeat()` method is called at least once during this period,
 or that you call one of the other channel or connection methods to send data
 over the connection. Heartbeats are sent by the server too, RabbitMQ also ensures
 that _some data_ is sent over the connection from the server to the client 

--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -1,20 +1,19 @@
 /**
  *  LibBoostAsio.cpp
- * 
+ *
  *  Test program to check AMQP functionality based on Boost's asio io_service.
- * 
+ *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
  *
- *  Compile with g++ -std=c++14 libboostasio.cpp -o boost_test -lpthread -lboost_system -lamqpcpp
+ *  Compile with:
+ *  g++ -std=c++17 -Wall  libboostasio.cpp -o boost_test  -lboost_system -lamqpcpp -lpthread -ldl
  */
 
 /**
  *  Dependencies
  */
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/strand.hpp>
-#include <boost/asio/deadline_timer.hpp>
-
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
 
 #include <amqpcpp.h>
 #include <amqpcpp/libboostasio.h>
@@ -25,32 +24,51 @@
  */
 int main()
 {
-
     // access to the boost asio handler
-    // note: we suggest use of 2 threads - normally one is fin (we are simply demonstrating thread safety).
-    boost::asio::io_service service(4);
+    boost::asio::io_context context;
 
-    // handler for libev
-    AMQP::LibBoostAsioHandler handler(service);
-    
+    // set of signal for process termination (CTRL-C, kill)
+    boost::asio::signal_set signals(context, SIGINT, SIGTERM);
+
+    // handler for libboostasio
+    AMQP::LibBoostAsioHandler handler(context);
+
     // make a connection
     AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://guest:guest@localhost/"));
-    
+
     // we need a channel too
     AMQP::TcpChannel channel(&connection);
-    
+
+    channel.onReady([&signals, &connection]() {
+        std::cout << "hit CTRL-C to exit\n\nchannel ready\n";
+
+        // install the signals handler
+        signals.async_wait([&connection](const boost::system::error_code& ec, int /* signal_number */)
+        {
+            if (!ec) {
+                // now we gently close the connection
+                std::cerr << "\nclosing connection...\n";
+                connection.close();
+            }
+        });
+    });
+    channel.onError([](const char *message) {
+        std::cerr << "channel error: " << message << std::endl;
+    });
+
     // create a temporary queue
-    channel.declareQueue(AMQP::exclusive).onSuccess([&connection](const std::string &name, uint32_t messagecount, uint32_t consumercount) {
-        
+    channel.declareQueue(AMQP::exclusive
+     ).onSuccess([](const std::string &name, uint32_t /* messagecount */, uint32_t /* consumercount */) {
+
         // report the name of the temporary queue
         std::cout << "declared queue " << name << std::endl;
-        
-        // now we can close the connection
-        connection.close();
-    });
-    
-    // run the handler
-    // a t the moment, one will need SIGINT to stop.  In time, should add signal handling through boost API.
-    return service.run();
-}
 
+    }).onError([](const char *message) {
+
+        // something went wrong creating the queue (or even before)
+        std::cerr << "declareQueue error: " << message << std::endl;
+    });
+
+    // run the handler
+    return context.run();
+}

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -178,7 +178,7 @@ protected:
         // store pointer
         _next = deferred;
     }
-    
+
     /**
      *  Remove this object from the chain of deferreds
      */
@@ -281,9 +281,6 @@ public:
      *  if and when the operation completes
      *  or fails. This function will be called
      *  either way.
-     *
-     *  In the case of success, the provided
-     *  error parameter will be an empty string.
      *
      *  Only one callback can be registered at at time.
      *  Successive calls to this function will clear

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -23,10 +23,11 @@
  *  Dependencies
  */
 #include <memory>
+#include <chrono>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/bind/bind.hpp>
@@ -83,10 +84,10 @@ protected:
         boost::asio::posix::stream_descriptor _socket;
 
         /**
-         *  The boost asynchronous deadline timer.
-         *  @var class boost::asio::deadline_timer
+         *  The boost asynchronous timer.
+         *  @var boost::asio::steady_timer
          */
-        boost::asio::deadline_timer _timer;
+        boost::asio::steady_timer _timer;
 
         /**
          *  A boolean that indicates if the watcher is monitoring for read events.
@@ -295,8 +296,8 @@ protected:
                     connection->heartbeat();
                 }
 
-                // Reschedule the timer for the future:
-                _timer.expires_at(_timer.expires_at() + boost::posix_time::seconds(timeout));
+                // reschedule the timer
+                _timer.expires_after(std::chrono::seconds(timeout));
 
                 // Posts the timer event
                 _timer.async_wait(get_timer_handler(connection, timeout));
@@ -387,11 +388,14 @@ protected:
             // stop timer in case it was already set
             stop_timer();
 
-            // Reschedule the timer for the future:
-            _timer.expires_from_now(boost::posix_time::seconds(timeout));
+            if (timeout)
+            {
+                // schedule the timer
+                _timer.expires_after(std::chrono::seconds(timeout));
 
-            // Posts the timer event
-            _timer.async_wait(get_timer_handler(connection, timeout));
+                // Posts the timer event
+                _timer.async_wait(get_timer_handler(connection, timeout));
+            }
         }
 
         /**
@@ -503,9 +507,7 @@ public:
     explicit LibBoostAsioHandler(boost::asio::io_context &io_context) :
         _iocontext(io_context),
         _strand(std::make_shared<boost::asio::io_context::strand>(_iocontext))
-        //_timer(std::make_shared<Timer>(_iocontext,_strand))
     {
-
     }
 
     /**

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -2,8 +2,8 @@
  *  LibBoostAsio.h
  *
  *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class
- *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the
- *  constructor and you're all set.  See tests/libboostasio.cpp for example.
+ *  instead of a AMQP::TcpHandler class, just pass the boost asio io_context to the
+ *  constructor and you're all set.  See examples/libboostasio.cpp for an example.
  *
  *  Watch out: this class was not implemented or reviewed by the original author of
  *  AMQP-CPP. However, we do get a lot of questions and issues from users of this class,
@@ -50,14 +50,14 @@ namespace AMQP {
  *  Class definition
  *  @note Because of a limitation on Windows, this will only work on POSIX based systems - see https://github.com/chriskohlhoff/asio/issues/70
  */
-class LibBoostAsioHandler : public virtual TcpHandler
+class LibBoostAsioHandler : public TcpHandler
 {
 protected:
 
     /**
      *  Helper class that wraps a boost io_context socket monitor.
      */
-    class Watcher : public virtual std::enable_shared_from_this<Watcher>
+    class Watcher : public std::enable_shared_from_this<Watcher>
     {
     private:
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -1,11 +1,11 @@
 /**
  *  LibBoostAsio.h
  *
- *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class 
- *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the 
+ *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class
+ *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the
  *  constructor and you're all set.  See tests/libboostasio.cpp for example.
  *
- *  Watch out: this class was not implemented or reviewed by the original author of 
+ *  Watch out: this class was not implemented or reviewed by the original author of
  *  AMQP-CPP. However, we do get a lot of questions and issues from users of this class,
  *  so we cannot guarantee its quality. If you run into such issues too, it might be
  *  better to implement your own handler that interact with boost.
@@ -13,7 +13,6 @@
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
  */
-
 
 /**
  *  Include guard
@@ -26,7 +25,7 @@
 #include <memory>
 
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/strand.hpp>
+#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
@@ -72,7 +71,7 @@ protected:
 
         /**
          *  The boost asio io_context::strand managed pointer.
-         *  @var class std::shared_ptr<boost::asio::io_context>
+         *  @var std::weak_ptr<boost::asio::io_context::strand>
          */
         strand_weak_ptr _wpstrand;
 
@@ -93,25 +92,25 @@ protected:
          *  A boolean that indicates if the watcher is monitoring for read events.
          *  @var _read True if reads are being monitored else false.
          */
-        bool _read{false};
+        bool _read = false;
 
         /**
          *  A boolean that indicates if the watcher has a pending read event.
-         *  @var _read True if read is pending else false.
+         *  @var _read_pending True if read is pending else false.
          */
-        bool _read_pending{false};
+        bool _read_pending = false;
 
         /**
          *  A boolean that indicates if the watcher is monitoring for write events.
-         *  @var _read True if writes are being monitored else false.
+         *  @var _write True if writes are being monitored else false.
          */
-        bool _write{false};
+        bool _write = false;
 
         /**
          *  A boolean that indicates if the watcher has a pending write event.
-         *  @var _read True if read is pending else false.
+         *  @var _write_pending True if read is pending else false.
          */
-        bool _write_pending{false};
+        bool _write_pending = false;
 
         using handler_cb = boost::function<void(boost::system::error_code,std::size_t)>;
         using io_handler = boost::function<void(const boost::system::error_code&, const std::size_t)>;
@@ -305,6 +304,7 @@ protected:
         }
 
     public:
+
         /**
          *  Constructor- initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
@@ -414,13 +414,13 @@ protected:
 
     /**
      *  The boost asio io_context::strand managed pointer.
-     *  @var class std::shared_ptr<boost::asio::io_context>
+     *  @var std::shared_ptr<boost::asio::io_context::strand>
      */
     strand_shared_ptr _strand;
 
     /**
-     *  All I/O watchers that are active, indexed by their filedescriptor
-     *  @var std::map<int,Watcher>
+     *  Active I/O watchers, indexed by their filedescriptor.
+     *  @var std::map<int, Watcher>
      */
     std::map<int, std::shared_ptr<Watcher> > _watchers;
 
@@ -460,11 +460,12 @@ protected:
         else
         {
             // Change the events on which to act.
-            iter->second->events(connection,fd,flags);
+            iter->second->events(connection, fd, flags);
         }
     }
 
 protected:
+
     /**
      *  Method that is called when the heartbeat frequency is negotiated between the server and the client.
      *  @param  connection      The connection that suggested a heartbeat interval
@@ -492,8 +493,6 @@ public:
 
     /**
      *  Handler cannot be default constructed.
-     *
-     *  @param  that    The object to not move or copy
      */
     LibBoostAsioHandler() = delete;
 
@@ -531,7 +530,6 @@ public:
      */
     ~LibBoostAsioHandler() override = default;
 };
-
 
 /**
  *  End of namespace

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -115,7 +115,6 @@ protected:
 
         using handler_cb = boost::function<void(boost::system::error_code)>;
         using io_handler = boost::function<void(const boost::system::error_code&)>;
-        using timer_cb = boost::function<void(boost::system::error_code)>;
 
         /**
          * Builds a io handler callback that executes the io callback in a strand.
@@ -129,12 +128,10 @@ protected:
             return [fn, wpstrand](const boost::system::error_code &ec)
             {
                 const strand_shared_ptr strand = wpstrand.lock();
-                if (!strand)
-                {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
-                    return;
-                }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
+                // is the strand still here?
+                if (!strand) return;
+
+                boost::asio::dispatch(*strand, boost::bind(fn, ec));
             };
         }
 
@@ -178,7 +175,7 @@ protected:
          * @param  timeout      The file descripter being watched.
          * @return handler callback
          */
-        timer_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
+        handler_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
         {
             const auto fn = boost::bind(&Watcher::timeout_handler,
                                   this,
@@ -186,19 +183,7 @@ protected:
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   timeout);
-
-            const strand_weak_ptr wpstrand = _wpstrand;
-
-            return [fn, wpstrand](const boost::system::error_code &ec)
-            {
-                const strand_shared_ptr strand = wpstrand.lock();
-                if (!strand)
-                {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
-                    return;
-                }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
-            };
+            return get_dispatch_wrapper(fn);
         }
 
         /**

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -113,9 +113,9 @@ protected:
          */
         bool _write_pending = false;
 
-        using handler_cb = boost::function<void(boost::system::error_code,std::size_t)>;
-        using io_handler = boost::function<void(const boost::system::error_code&, const std::size_t)>;
-        using timer_handler = boost::function<void(boost::system::error_code)>;
+        using handler_cb = boost::function<void(boost::system::error_code)>;
+        using io_handler = boost::function<void(const boost::system::error_code&)>;
+        using timer_cb = boost::function<void(boost::system::error_code)>;
 
         /**
          * Builds a io handler callback that executes the io callback in a strand.
@@ -126,15 +126,15 @@ protected:
         {
             const strand_weak_ptr wpstrand = _wpstrand;
 
-            return [fn, wpstrand](const boost::system::error_code &ec, const std::size_t bytes_transferred)
+            return [fn, wpstrand](const boost::system::error_code &ec)
             {
                 const strand_shared_ptr strand = wpstrand.lock();
                 if (!strand)
                 {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled), std::size_t{0});
+                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
                     return;
                 }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec, bytes_transferred));
+                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
             };
         }
 
@@ -149,7 +149,6 @@ protected:
             auto fn = boost::bind(&Watcher::read_handler,
                                   this,
                                   boost::placeholders::_1,
-                                  boost::placeholders::_2,
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
@@ -167,7 +166,6 @@ protected:
             auto fn = boost::bind(&Watcher::write_handler,
                                   this,
                                   boost::placeholders::_1,
-                                  boost::placeholders::_2,
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
@@ -180,7 +178,7 @@ protected:
          * @param  timeout      The file descripter being watched.
          * @return handler callback
          */
-        timer_handler get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
+        timer_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
         {
             const auto fn = boost::bind(&Watcher::timeout_handler,
                                   this,
@@ -206,14 +204,12 @@ protected:
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a read event.
          *  @param  ec          The status of the callback.
-         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a read is cancelled.
          */
         void read_handler(const boost::system::error_code &ec,
-                          const std::size_t bytes_transferred,
                           const std::weak_ptr<Watcher> awpWatcher,
                           TcpConnection *const connection,
                           const int fd)
@@ -225,29 +221,31 @@ protected:
 
             _read_pending = false;
 
-            if ((!ec || ec == boost::asio::error::would_block) && _read)
+            if (!ec && _read)
             {
                 connection->process(fd, AMQP::readable);
 
-                _read_pending = true;
+                // still we need monitoring read?
+                if (_socket.is_open())
+                {
+                    _read_pending = true;
 
-                _socket.async_read_some(
-                    boost::asio::null_buffers(),
-                    get_read_handler(connection, fd));
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_read,
+                        get_read_handler(connection, fd));
+                }
             }
         }
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a write event.
          *  @param  ec          The status of the callback.
-         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a write is cancelled.
          */
         void write_handler(const boost::system::error_code ec,
-                           const std::size_t bytes_transferred,
                            const std::weak_ptr<Watcher> awpWatcher,
                            TcpConnection *const connection,
                            const int fd)
@@ -259,15 +257,19 @@ protected:
 
             _write_pending = false;
 
-            if ((!ec || ec == boost::asio::error::would_block) && _write)
+            if (!ec && _write)
             {
                 connection->process(fd, AMQP::writable);
 
-                _write_pending = true;
+                // still we need monitoring write?
+                if (_socket.is_open())
+                {
+                    _write_pending = true;
 
-                _socket.async_write_some(
-                    boost::asio::null_buffers(),
-                    get_write_handler(connection, fd));
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_write,
+                        get_write_handler(connection, fd));
+                }
             }
         }
 
@@ -277,6 +279,7 @@ protected:
          *  @param  loop        The loop in which the event was triggered
          *  @param  connection
          *  @param  timeout
+         *  @note   The handler will get called if a timer is cancelled.
          */
         void timeout_handler(const boost::system::error_code &ec,
                      std::weak_ptr<Watcher> awpThis,
@@ -359,8 +362,8 @@ protected:
             {
                 _read_pending = true;
 
-                _socket.async_read_some(
-                    boost::asio::null_buffers(),
+                _socket.async_wait(
+                    boost::asio::posix::stream_descriptor::wait_read,
                     get_read_handler(connection, fd));
             }
 
@@ -372,8 +375,8 @@ protected:
             {
                 _write_pending = true;
 
-                _socket.async_write_some(
-                    boost::asio::null_buffers(),
+                _socket.async_wait(
+                    boost::asio::posix::stream_descriptor::wait_write,
                     get_write_handler(connection, fd));
             }
         }

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -27,7 +27,7 @@ namespace AMQP {
 TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
     _handler(handler),
     _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), ConnectionOrder(address.option("connectionOrder")))),
-    _connection(this, address.login(), address.vhost()) 
+    _connection(this, address.login(), address.vhost())
 {
     // tell the handler
     _handler->onAttached(this);
@@ -97,8 +97,8 @@ void TcpConnection::process(int fd, int flags)
 
     // remember the old state
     auto *oldstate = _state.get();
-        
-    // pass on the the state, that returns a new impl
+
+    // pass on the state, that returns a new impl
     auto *newstate = _state->process(monitor, fd, flags);
 
     // if the state did not change, we do not have to update a member,
@@ -109,7 +109,7 @@ void TcpConnection::process(int fd, int flags)
     // wrap the new state in a unique-ptr so that so that the old state
     // is not destructed before the new one is assigned
     std::unique_ptr<TcpState> ptr(newstate);
-    
+
     // swap the two pointers (this ensures that the last operation of this
     // method is to destruct the old state, which possible results in calls
     // to user-space and the destruction of "this"
@@ -118,7 +118,7 @@ void TcpConnection::process(int fd, int flags)
 }
 
 /**
- *  Close the connection. 
+ *  Close the connection.
  *  Warning: this potentially directly calls several handlers (onError, onLost, onDetached)
  *  @return bool
  */
@@ -129,10 +129,10 @@ bool TcpConnection::close(bool immediate)
 
     // failing the connection could destruct "this"
     Monitor monitor(this);
-    
+
     // fail the connection / report the error to user-space
     bool failed = _connection.fail("connection prematurely closed by client");
-    
+
     // stop if object was destructed
     if (!monitor.valid()) return true;
 
@@ -142,7 +142,7 @@ bool TcpConnection::close(bool immediate)
     // stop if object was destructed
     if (!monitor.valid()) return true;
 
-    // also call the lost handler, we have now lost the connection from this state (since we force-closed). 
+    // also call the lost handler, we have now lost the connection from this state (since we force-closed).
     // this makes sure the onLost and onDetached is properly called.
     onLost(_state.get());
 
@@ -157,7 +157,7 @@ bool TcpConnection::close(bool immediate)
 }
 
 /**
- *  Method that is called when the RabbitMQ server and your client application  
+ *  Method that is called when the RabbitMQ server and your client application
  *  exchange some properties that describe their identity.
  *  @param  connection      The connection about which information is exchanged
  *  @param  server          Properties sent by the server
@@ -179,7 +179,7 @@ uint16_t TcpConnection::onNegotiate(Connection *connection, uint16_t interval)
 {
     // tell the max-frame size
     _state->maxframe(connection->maxFrame());
-    
+
     // tell the handler
     return _handler ? _handler->onNegotiate(this, interval) : interval;
 }
@@ -205,13 +205,13 @@ void TcpConnection::onError(Connection *connection, const char *message)
 {
     // monitor to check if "this" is destructed
     Monitor monitor(this);
-    
+
     // tell this to the user
     if (_handler) _handler->onError(this, message);
-    
+
     // object could be destructed by user-space
     if (!monitor.valid()) return;
-    
+
     // tell the state that the connection should be closed asap
     _state->close();
 }
@@ -224,7 +224,7 @@ void TcpConnection::onClosed(Connection *connection)
 {
     // tell the state that the connection should be closed asap
     _state->close();
-    
+
     // report to the handler
     _handler->onClosed(this);
 }
@@ -242,10 +242,10 @@ void TcpConnection::onError(TcpState *state, const char *message, bool connected
 
     // monitor to check if all operations are active
     Monitor monitor(this);
-    
+
     // if there are still pending operations, they should be reported as error
     bool failed = _connection.fail(message);
-    
+
     // stop if object was destructed
     if (!monitor.valid()) return;
 
@@ -255,7 +255,7 @@ void TcpConnection::onError(TcpState *state, const char *message, bool connected
     // if the object is still connected, we only have to report the error and
     // we wait for the subsequent call to the onLost() method
     if (connected || !monitor.valid()) return;
-    
+
     // tell the handler that no further events will be fired
     _handler->onDetached(this);
 }
@@ -268,16 +268,16 @@ void TcpConnection::onLost(TcpState *state)
 {
     // if user-space is no longer interested in this object, the rest of the code is pointless here
     if (_handler == nullptr) return;
-    
+
     // monitor to check if "this" is destructed
     Monitor monitor(this);
-    
+
     // tell the handler
     _handler->onLost(this);
-    
+
     // leap out if object was destructed
     if (!monitor.valid()) return;
-    
+
     // tell the handler that no further events will be fired
     _handler->onDetached(this);
 }


### PR DESCRIPTION
This PR is the result of the initial factorization of #550 (hence it's first child).

After each commit included in the PR I checked that there were no regressions, having more revisions will make the review easier. If @zerodefect thinks it's useful I can merge them into a single revision for the merge.

+ 062d92f Update and clean up documentation (README and code)
+ 6be5e1b Better example test, fixed `io_contex::strand` header, comments cleanup
+ 0291bd2 End of virtual inheritance abuse (why this?)
+ 5b32219 Abandon the deprecated `deadline_timer`
+ 3c0c4d6 Abandonment of deprecated `null_buffers`, this made it necessary to convert the `async_read_some`/`async_write_some` to `async_wait` and consequently also the callback prototype (fortunately); Furthermore, these methods never return a `boost::asio::error::would_block` error if the socket is non-blocking.
+ f7c4726 At this point the handlers are starting to become a little more homogeneous, but the real change is yet to come.