### PR TITLE
libuv fully refactored

### DIFF
--- a/examples/libuv.cpp
+++ b/examples/libuv.cpp
@@ -22,7 +22,7 @@
  * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
  *
  *
- *  libUV.cpp
+ *  LibUV.cpp
  *
  *  Test program to check AMQP functionality based on libuv.
  *

--- a/examples/libuv.cpp
+++ b/examples/libuv.cpp
@@ -1,18 +1,135 @@
-/**
- *  LibUV.cpp
- * 
- *  Test program to check AMQP functionality based on LibUV
- * 
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
+ *
+ * Copyright 2025 Copernica BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
+ *  libUV.cpp
+ *
+ *  Test program to check AMQP functionality based on libuv.
+ *
+ *  Compile with (append -lssl if #define USE_AMQPS):
+ *  g++ -std=c++17 -Wall -Wno-class-conversion libuv.cpp -o libuv -luv -lamqpcpp -lpthread -ldl
+ *
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2015 - 2017 Copernica BV
+ *  @author Paolo Pastori
  */
+
+/*
+ * uncomment (and link with -lssl) to use amqps instead of plain amqp
+ */
+//#define USE_AMQPS
 
 /**
  *  Dependencies
  */
 #include <uv.h>
+#ifdef USE_AMQPS
+#include <openssl/ssl.h>
+#include <openssl/opensslv.h>
+#endif // USE_AMQPS
+#include <iomanip>
+
 #include <amqpcpp.h>
 #include <amqpcpp/libuv.h>
+
+
+/**
+ *  Class that runs a timer
+ */
+class MyTimer
+{
+private:
+    /**
+     *  The asynchronous timer handle
+     *  @var uv_timer_t
+     */
+    uv_timer_t *_timer;
+
+    /**
+     *  The AMQP channel
+     *  @var AMQP::TcpChannel
+     */
+    AMQP::TcpChannel *_pchannel;
+
+    /**
+     *  Name of the queue
+     *  @var std::string
+     */
+    std::string _queue;
+
+    /**
+     *  Callback method that is called by libuv when the timer fires
+     *  @param  handle  timer handle
+     */
+    static void callback(uv_timer_t *handle)
+    {
+        // counter for published messages
+        static uint32_t pno = 0;
+
+        // retrieve this
+        MyTimer *self = static_cast<MyTimer*>(handle->data);
+
+        // publish a message
+        self->_pchannel->publish("", self->_queue, "Hello World");
+
+        std::cout << "message " << ++pno << " published" << std::endl;
+    }
+
+public:
+    /**
+     *  Constructor
+     *  @param  loop     The event loop
+     *  @param  channel  The channel to use
+     *  @param  queue    The name of the queue to use
+     */
+    MyTimer(uv_loop_t *loop, AMQP::TcpChannel *channel, std::string queue) :
+        _pchannel(channel), _queue(queue)
+    {
+        // create a new timer
+        _timer = new uv_timer_t();
+
+        // initialize the timer handle
+        uv_timer_init(loop, _timer);
+
+        // store "this" in the data field (void*)
+        _timer->data = this;
+
+        // start the timer
+        uv_timer_start(_timer, callback, 5, 1005);
+    }
+
+    /**
+     *  Destructor
+     */
+    ~MyTimer()
+    {
+        // stop the timer
+        uv_timer_stop(_timer);
+
+        // close the timer handle
+        UV_AUX::close_handle(_timer);
+    }
+};
+
 
 /**
  *  Custom handler
@@ -22,35 +139,190 @@ class MyHandler : public AMQP::LibUvHandler
 private:
     /**
      *  Method that is called when a connection error occurs
-     *  @param  connection
-     *  @param  message
+     *  @param  connection  The TCP connection
+     *  @param  message     The error message
      */
-    virtual void onError(AMQP::TcpConnection *connection, const char *message) override
+    void onError(AMQP::TcpConnection* /* connection */, const char *message) override
     {
-        std::cout << "error: " << message << std::endl;
+        std::cout << "error: " << std::quoted(message) << std::endl;
     }
 
     /**
      *  Method that is called when the TCP connection ends up in a connected state
      *  @param  connection  The TCP connection
      */
-    virtual void onConnected(AMQP::TcpConnection *connection) override 
+    void onConnected(AMQP::TcpConnection *connection) override
     {
-        std::cout << "connected" << std::endl;
+        std::cout << "connected\n";
+
+        // save the connection to close and start the signal
+        _conn_to_close = connection;
+        uv_signal_start(_signal, sig_callabck, SIGINT);
+
+        std::cout << "\n  Hit CTRL-C to exit\n" << std::endl;
     }
-    
+
+    /**
+     *  Method that is called when the TCP connection ends up in a ready
+     *  @param  connection  The TCP connection
+     */
+    void onReady(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "ready" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is closed
+     *  @param  connection  The TCP connection
+     */
+    void onClosed(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "closed" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection was blocked
+     *  @param  connection      The connection that was blocked
+     *  @param  reason          Why was the connection blocked
+     */
+    void onBlocked(AMQP::TcpConnection* /* connection */, const char *reason) override
+    {
+        std::cout << "blocked with reason " << std::quoted(reason) << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is no longer blocked
+     *  @param  connection      The connection that is no longer blocked
+     */
+    void onUnblocked(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "unblocked" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is lost or closed
+     *  @param  connection  The TCP connection
+     */
+    void onLost(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "lost" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is detached
+     *  @param  connection  The TCP connection
+     */
+    void onDetached(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "detached" << std::endl;
+    }
+
+
+    /**
+     *  The signal handle to be used for process termination
+     *  @var uv_signal_t
+     */
+    uv_signal_t *_signal;
+
+    /**
+     *  The connection to be closed when pressing CTRL-C
+     *  @var TcpConnection
+     */
+    AMQP::TcpConnection *_conn_to_close = nullptr;
+
+    /**
+     *  The timer used for periodical publishing
+     *  @var MyTimer
+     */
+    MyTimer *_mytimer = nullptr;
+
+    /**
+     * Callback method that is called by libuv when a signal is catched
+     * @param  handle  signal handle
+     * @param  signum  signal number
+     */
+    static void sig_callabck(uv_signal_t *handle, int signum)
+    {
+        // retrieve this
+        MyHandler *self = static_cast<MyHandler*>(handle->data);
+
+        if (self->_conn_to_close) {
+
+            std::cerr << "\nclosing connection...\n";
+            // now we gently close the connection
+            self->_conn_to_close->close();
+
+            // NOTE: we have to deactivate all handles to leave event loop
+            //       otherwise the process will hang
+            uv_signal_stop(handle);
+            self->stop_timer();
+        }
+    }
+
 public:
+
     /**
      *  Constructor
-     *  @param  uv_loop
+     *  @param  loop  The event loop
      */
-    MyHandler(uv_loop_t *loop) : AMQP::LibUvHandler(loop) {}
+    MyHandler(uv_loop_t *loop) : AMQP::LibUvHandler(loop)
+    {
+        // create a new signal
+        _signal = new uv_signal_t();
+
+        // initialize the signal handle
+        uv_signal_init(loop, _signal);
+
+        // store "this" in the data field (void*)
+        _signal->data = this;
+    }
+
+    /**
+     *  Install the user timer
+     */
+    void set_timer(MyTimer *timer)
+    {
+        _mytimer = timer;
+    }
+
+    /**
+     *  Stop the timer
+     */
+    void stop_timer()
+    {
+        if (_mytimer)
+        {
+            delete _mytimer;
+            _mytimer = nullptr;
+        }
+    }
+
+    /**
+     *  Stop listening for signals
+     */
+    void stop_signals()
+    {
+        uv_signal_stop(_signal);
+        // to deactivate may also call unref as alternative,
+        // see https://docs.libuv.org/en/v1.x/handle.html#c.uv_unref
+        //uv_unref(reinterpret_cast<uv_handle_t*>(_signal));
+    }
 
     /**
      *  Destructor
      */
-    virtual ~MyHandler() = default;
+    virtual ~MyHandler()
+    {
+        // stop the signal
+        uv_signal_stop(_signal);
+
+        // close the signal handle
+        UV_AUX::close_handle(_signal);
+
+        stop_timer();
+    }
 };
+
 
 /**
  *  Main program
@@ -58,29 +330,84 @@ public:
  */
 int main()
 {
-    // access to the event loop
+    // the event loop
     auto *loop = uv_default_loop();
-    
-    // handler for libev
+
+    // the handler
     MyHandler handler(loop);
-    
+
+#ifdef USE_AMQPS
+    // init the SSL library
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_library_init();
+#else
+    OPENSSL_init_ssl(0, NULL);
+#endif
+
+    AMQP::Address address("amqps://guest:guest@localhost/");
+#else
+    AMQP::Address address("amqp://guest:guest@localhost/");
+#endif // USE_AMQPS
+
     // make a connection
-    AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://guest:guest@localhost/"));
-    
-    // we need a channel too
+    AMQP::TcpConnection connection(&handler, address);
+
+    // make a channel
     AMQP::TcpChannel channel(&connection);
-    
+
     // create a temporary queue
-    channel.declareQueue(AMQP::exclusive).onSuccess([&connection](const std::string &name, uint32_t messagecount, uint32_t consumercount) {
-        
-        // report the name of the temporary queue
-        std::cout << "declared queue " << name << std::endl;
+    channel.declareQueue(AMQP::exclusive)
+      .onSuccess([&connection, &channel, &handler, loop](const std::string &queuename, uint32_t messagecount, uint32_t consumercount) {
+
+        std::cout << "declared queue " << std::quoted(queuename) << std::endl;
+
+/*        // close the channel
+        channel.close().onSuccess([&connection, &handler]() {
+
+            std::cout << "channel closed" << std::endl;
+
+            // close the connection
+            connection.close();
+
+            // NOTE: we have to deactivate all handles to leave event loop
+            //       otherwise the process will hang
+            handler.stop_signals();
+
+        }); */
+
+        // start a consumer
+        channel.consume(queuename).onReceived([&channel, queuename](const AMQP::Message &message, uint64_t deliveryTag, bool redelivered) {
+
+            std::cout << "received " << deliveryTag << std::endl;
+
+/*            // we remove the queue, to see if this indeed triggers the onCancelled method
+            if (deliveryTag > 4) channel.removeQueue(queuename); */
+
+            // ack the message
+            channel.ack(deliveryTag);
+
+        }).onSuccess([&handler, loop, &channel, queuename](const std::string &tag) {
+
+            // the consumer is ready
+            std::cout << "started consuming with tag " << std::quoted(tag) << std::endl;
+
+            // start the publisher too
+            handler.set_timer(new MyTimer(loop, &channel, queuename));
+
+        }).onCancelled([&handler](const std::string &tag) {
+
+            // the consumer was cancelled by the server
+            std::cout << "consumer " << std::quoted(tag) << " was cancelled" << std::endl;
+
+            // stop the publisher
+            handler.stop_timer();
+
+        });
     });
-    
-    // run the loop
+
+    // run the event loop
     uv_run(loop, UV_RUN_DEFAULT);
 
-    // done
     return 0;
 }
 

--- a/include/amqpcpp/libuv.h
+++ b/include/amqpcpp/libuv.h
@@ -22,7 +22,7 @@
  * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
  *
  *
- *  libUV.h
+ *  LibUV.h
  *
  *  Implementation for the AMQP::TcpHandler that is optimized for libuv. You can
  *  use this class instead of a AMQP::TcpHandler class, just pass the event loop
@@ -158,6 +158,12 @@ private:
         uint64_t _expire;
 
         /**
+         *  The events for which the filedescriptor is actually monitored.
+         *  @var int
+         */
+        int _events = 0;
+
+        /**
          *  Callback method that is called by libuv when a filedescriptor becomes active
          *  @param  handle   io handle
          *  @param  status   LibUV error code UV_*, see https://docs.libuv.org/en/v1.x/errors.html
@@ -277,6 +283,9 @@ private:
             _poll->data = this;
             _timer->data = this;
 
+            // remember current event mask
+            _events = events;
+
             // start the watcher
             uv_poll_start(_poll, events, io_callback);
         }
@@ -313,10 +322,8 @@ private:
          */
         void set_event_mask(int events)
         {
-            // save last event mask to avoid useless handle update,
+            // avoid useless handle update,
             // see https://docs.libuv.org/en/v1.x/poll.html
-            static int _events = 0;
-
             if (events != _events)
             {
                 // update the events being watched for
@@ -428,9 +435,6 @@ private:
 
             // apply server connection timeout monitor
             upwatcher->apply_connection_timeout();
-
-            // explicitly set the events to monitor
-            upwatcher->set_event_mask(flags);
         }
         else if (flags == 0)
         {
@@ -474,7 +478,8 @@ public:
 
     /**
      *  Constructor
-     *  @param  loop    The event loop to wrap
+     *  @param  loop                The event loop to wrap
+     *  @param  connection_timeout  The AMQP server connection timeout (seconds)
      */
     LibUvHandler(uv_loop_t *loop, uint16_t connection_timeout = 60)
         : _loop(loop), _connection_timeout(connection_timeout)

--- a/include/amqpcpp/libuv.h
+++ b/include/amqpcpp/libuv.h
@@ -46,6 +46,7 @@
 // >= C++14, using make_unique
 #include <memory>
 #endif
+#include <type_traits>
 #include <map>
 #include <cassert>
 
@@ -79,7 +80,8 @@ namespace UV_AUX {
      * Helper template function for closing libuv handles,
      * see https://docs.libuv.org/en/v1.x/handle.html#c.uv_close
      */
-    template <typename H>
+    template <typename H,
+         typename = std::enable_if_t<std::is_same<H, uv_poll_t>::value || std::is_same<H, uv_timer_t>::value || std::is_same<H, uv_signal_t>::value > >
     void close_handle(H *handle)
     {
         uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* hndl) {
@@ -173,7 +175,7 @@ private:
         {
             Watcher *self = static_cast<Watcher*>(handle->data);
 
-            // is the socket still open()?
+            // is the socket still open?
             int fd = ::UV_AUX::handle_fileno(handle);
             if (fd != -1)
             {
@@ -211,7 +213,7 @@ private:
         {
             Watcher *self = static_cast<Watcher*>(handle->data);
 
-            // is the socket still open()?
+            // is the socket still open?
             int fd = ::UV_AUX::handle_fileno(self->_poll);
             if (fd != -1)
             {

--- a/include/amqpcpp/libuv.h
+++ b/include/amqpcpp/libuv.h
@@ -1,14 +1,36 @@
-/**
- *  LibUV.h
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
+ *
+ * Copyright 2025 Copernica BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
+ *  libUV.h
  *
  *  Implementation for the AMQP::TcpHandler that is optimized for libuv. You can
  *  use this class instead of a AMQP::TcpHandler class, just pass the event loop
- *  to the constructor and you're all set.
+ *  to the constructor and you're all set.  See examples/libuv.cpp for an example.
  *
- *  Based heavily on the libev.h implementation by Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
  *
  *  @author David Nikdel <david@nikdel.com>
- *  @copyright 2015 Copernica BV
+ *  @author Paolo Pastori
  */
 
 /**
@@ -20,8 +42,53 @@
  *  Dependencies
  */
 #include <uv.h>
+#if __cplusplus >= 201402L
+// >= C++14, using make_unique
+#include <memory>
+#endif
+#include <map>
+#include <cassert>
 
 #include "amqpcpp/linux_tcp.h"
+
+
+// TODO: maybe for AMQP-CPP VERSION > 4.3.27 we can use
+//       these in place of the assert placed into ctor
+//static_assert(AMQP::readable == UV_READABLE, "libuv vs AMQP-CPP flags mismatch");
+//static_assert(AMQP::writable == UV_WRITABLE, "libuv vs AMQP-CPP flags mismatch");
+
+/**
+ *  Set up auxiliary namespace
+ */
+namespace UV_AUX {
+
+    /*
+     * Helper template function for getting libuv handle file descriptor,
+     * see https://docs.libuv.org/en/v1.x/handle.html#c.uv_fileno
+     * @return int
+     */
+    template <typename H>
+    int handle_fileno(H *handle)
+    {
+        int fd = -1;
+        (void) uv_fileno(reinterpret_cast<uv_handle_t*>(handle), &fd);
+        return fd;
+    }
+
+    /*
+     * Helper template function for closing libuv handles,
+     * see https://docs.libuv.org/en/v1.x/handle.html#c.uv_close
+     */
+    template <typename H>
+    void close_handle(H *handle)
+    {
+        uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* hndl) {
+            // delete memory once closed
+            delete reinterpret_cast<H*>(hndl);
+        });
+    }
+}
+
 
 /**
  *  Set up namespace
@@ -35,11 +102,17 @@ class LibUvHandler : public TcpHandler
 {
 private:
     /**
-     *  Helper class that wraps a libev I/O watcher
+     *  Helper class that wraps a libuv I/O watcher
      */
     class Watcher
     {
     private:
+        /**
+         *  The connection being watched
+         *  @var TcpConnection
+         */
+        TcpConnection *_connection;
+
         /**
          *  The event loop to which it is attached
          *  @var uv_loop_t
@@ -47,49 +120,165 @@ private:
         uv_loop_t *_loop;
 
         /**
-         *  The actual watcher structure
+         *  The asynchronous io handle
          *  @var uv_poll_t
          */
         uv_poll_t *_poll;
 
         /**
-         *  Callback method that is called by libuv when a filedescriptor becomes active
-         *  @param  handle     Internal poll handle
-         *  @param  status     LibUV error code UV_*
-         *  @param  events     Events triggered
+         *  The asynchronous timer handle
+         *  @var uv_timer_t
          */
-        static void callback(uv_poll_t *handle, int status, int events)
-        {
-            // retrieve the connection
-            TcpConnection *connection = static_cast<TcpConnection*>(handle->data);
+        uv_timer_t *_timer;
 
-            // tell the connection that its filedescriptor is active
-            int fd = -1;
-            uv_fileno(reinterpret_cast<uv_handle_t*>(handle), &fd);
-            connection->process(fd, uv_to_amqp_events(status, events));
+        /**
+         *  AMQP Server connection timeout setting (seconds)
+         *  @var uint16_t
+         */
+        uint16_t _connection_timeout = 0;
+
+        /**
+         *  Timeout after which the connection is no longer considered alive.
+         *  A heartbeat must be sent every _timeout / 2 seconds.
+         *  Value zero means heartbeats are disabled, or not yet negotiated.
+         *  @var uint16_t
+         */
+        uint16_t _timeout = 0;
+
+        /**
+         *  When should we send the next heartbeat?
+         *  @var uint64_t
+         */
+        uint64_t _next;
+
+        /**
+         *  When does the connection expire / was the server idle for too long?
+         *  @var uint64_t
+         */
+        uint64_t _expire;
+
+        /**
+         *  Callback method that is called by libuv when a filedescriptor becomes active
+         *  @param  handle   io handle
+         *  @param  status   LibUV error code UV_*, see https://docs.libuv.org/en/v1.x/errors.html
+         *  @param  events   Events triggered
+         */
+        static void io_callback(uv_poll_t *handle, int status, int events)
+        {
+            Watcher *self = static_cast<Watcher*>(handle->data);
+
+            // is the socket still open()?
+            int fd = ::UV_AUX::handle_fileno(handle);
+            if (fd != -1)
+            {
+                // if an error happens while polling, status will be < 0
+                // and corresponds with one of the UV_E* error codes
+                if (status)
+                {
+//std::cerr << "LibUvHandler::Watcher::io_callback() error UV_" << uv_err_name(status) << ", events " << events << ", fd " << fd << '\n';
+                    // report rw condition to library to pick up the error
+                    events = AMQP::readable | AMQP::writable;
+                }
+                else
+                {
+                    if (events & AMQP::readable)
+                    {
+                        // the server is sending data, update the _expire time
+                        self->_expire = uv_now(self->_loop) + self->_timeout * 1500;
+                    }
+                    if (events & AMQP::writable)
+                    {
+                        // the client is sending data, update the _next time
+                        self->_next = uv_now(self->_loop) + self->_timeout * 500;
+                    }
+                }
+
+                self->_connection->process(fd, events);
+            }
+        }
+
+        /**
+         *  Callback method that is called by libuv when a timer fires
+         *  @param  handle   timer handle
+         */
+        static void timer_callback(uv_timer_t *handle)
+        {
+            Watcher *self = static_cast<Watcher*>(handle->data);
+
+            // is the socket still open()?
+            int fd = ::UV_AUX::handle_fileno(self->_poll);
+            if (fd != -1)
+            {
+                uint64_t now = uv_now(self->_loop);
+
+                if (self->_timeout == 0)
+                {
+                    // this can happen in three situations:
+                    // 1. a connection timeout,
+                    // 2. user space has overidden onNegotiate to reject heartbeats
+                    // 3. AMQP server does not want heartbeats
+                    // in either case we're no longer going to run further timers.
+
+                    // if we have an initialized connection, user space must have overidden
+                    // the onNegotiate method, so we keep using the connection
+                    if (self->_connection->initialized()) return;
+
+                    // this is a connection timeout, close the connection with immediate effect
+                    return (void) self->_connection->close(true);
+                }
+                else if (now >= self->_expire)
+                {
+                    // the server was inactive for a too long period of time,
+                    // close the connection with immediate effect
+                    self->_timeout = 0;
+                    return (void) self->_connection->close(true);
+                }
+                else if (now >= self->_next)
+                {
+                    // send the heartbeat
+                    self->_connection->heartbeat();
+
+                    // when we should send out the next one
+                    self->_next = now + self->_timeout * 500;
+                }
+
+                // reschedule the timer
+                uv_timer_start(self->_timer, timer_callback, self->_timeout * 500, 0);
+            }
         }
 
     public:
+
         /**
          *  Constructor
-         *  @param  loop            The current event loop
-         *  @param  connection      The connection being watched
-         *  @param  fd              The filedescriptor being watched
-         *  @param  events          The events that should be monitored
+         *  @param  loop                The current event loop
+         *  @param  connection          The connection being watched
+         *  @param  connection_timeout  The AMQP server connection timeout
+         *  @param  fd                  The filedescriptor being watched
+         *  @param  events              The events that should be monitored
          */
-        Watcher(uv_loop_t *loop, TcpConnection *connection, int fd, int events) : _loop(loop)
+        Watcher(uv_loop_t *loop,
+                TcpConnection *connection,
+                uint16_t connection_timeout,
+                int fd,
+                int events) :
+            _connection(connection), _loop(loop), _connection_timeout(connection_timeout)
         {
             // create a new poll
             _poll = new uv_poll_t();
+            // create a new timer
+            _timer = new uv_timer_t();
 
-            // initialize the libev structure
+            // initialize the libuv handles
             uv_poll_init(_loop, _poll, fd);
+            uv_timer_init(loop, _timer);
 
-            // store the connection in the data "void*"
-            _poll->data = connection;
+            // store "this" in the data fields (void*)
+            _poll->data = this;
+            _timer->data = this;
 
             // start the watcher
-            uv_poll_start(_poll, amqp_to_uv_events(events), callback);
+            uv_poll_start(_poll, events, io_callback);
         }
 
         /**
@@ -108,57 +297,87 @@ private:
             // stop the watcher
             uv_poll_stop(_poll);
 
-            // close the handle
-            uv_close(reinterpret_cast<uv_handle_t*>(_poll), [](uv_handle_t* handle) {
-                // delete memory once closed
-                delete reinterpret_cast<uv_poll_t*>(handle);
-            });
+            // close the io handle
+            ::UV_AUX::close_handle(_poll);
+
+            // stop the timer
+            stop_timer();
+
+            // close the timer handle
+            ::UV_AUX::close_handle(_timer);
         }
 
         /**
-         *  Change the events for which the filedescriptor is monitored
-         *  @param  events
+         *  Set the events for which the filedescriptor is monitored
+         *  @param  events  The events to monitor (readable, writable or both)
          */
-        void events(int events)
+        void set_event_mask(int events)
         {
-            // update the events being watched for
-            uv_poll_start(_poll, amqp_to_uv_events(events), callback);
-        }
+            // save last event mask to avoid useless handle update,
+            // see https://docs.libuv.org/en/v1.x/poll.html
+            static int _events = 0;
 
-    private:
+            if (events != _events)
+            {
+                // update the events being watched for
+                uv_poll_start(_poll, events, io_callback);
 
-        /**
-         *  Convert event flags from UV format to AMQP format
-         */
-        static int uv_to_amqp_events(int status, int events)
-        {
-            // if the socket is closed report both so we pick up the error
-            if (status != 0)
-                return AMQP::readable | AMQP::writable;
-
-            // map read or write
-            int amqp_events = 0;
-            if (events & UV_READABLE)
-                amqp_events |= AMQP::readable;
-            if (events & UV_WRITABLE)
-                amqp_events |= AMQP::writable;
-            return amqp_events;
+                // remember current event mask
+                _events = events;
+            }
         }
 
         /**
-         *  Convert event flags from AMQP format to UV format
+         *  Apply AMQP server connection timeout watching
          */
-        static int amqp_to_uv_events(int events)
+        void apply_connection_timeout()
         {
-            int uv_events = 0;
-            if (events & AMQP::readable)
-                uv_events |= UV_READABLE;
-            if (events & AMQP::writable)
-                uv_events |= UV_WRITABLE;
-            return uv_events;
+            if (_connection_timeout && !_timeout)
+            {
+                // schedule the timer
+                uv_timer_start(_timer, timer_callback, _connection_timeout * 1000, 0);
+            }
+        }
+
+        /**
+         *  Configure the heartbeat interval to use
+         *  @param timeout  The timeout value (seconds, 0 to disable heartbeat monitor.)
+         */
+        void set_heartbeat(uint16_t timeout)
+        {
+            _timeout = timeout;
+        }
+
+        /**
+         *  Schedule the timer
+         */
+        void set_timer()
+        {
+            // stop timer in case it was already set
+            stop_timer();
+
+            if (_timeout)
+            {
+                uint64_t now = uv_now(_loop);
+                // when we should send out the next heartbeat
+                _next = now + _timeout * 500;
+                // by when we should expect some server activity
+                _expire = _next + _timeout * 1000;
+
+                // schedule the timer
+                uv_timer_start(_timer, timer_callback, _timeout * 500, 0);
+            }
+        }
+
+        /**
+         *  Stop the timer
+         */
+        void stop_timer()
+        {
+            // do nothing if it was never set
+            uv_timer_stop(_timer);
         }
     };
-
 
     /**
      *  The event loop
@@ -170,8 +389,13 @@ private:
      *  All I/O watchers that are active, indexed by their filedescriptor
      *  @var std::map<int,Watcher>
      */
-    std::map<int,std::unique_ptr<Watcher>> _watchers;
+    std::map<int, std::unique_ptr<Watcher>> _watchers;
 
+    /**
+     *  AMQP Server connection timeout setting (seconds)
+     *  @var uint16_t
+     */
+    uint16_t _connection_timeout;
 
     /**
      *  Method that is called by AMQP-CPP to register a filedescriptor for readability or writability
@@ -187,30 +411,87 @@ private:
         // was it found?
         if (iter == _watchers.end())
         {
-            // we did not yet have this watcher - but that is ok if no filedescriptor was registered
+            // a new watcher is required
+
+            // skip if no read/write activity to monitor
             if (flags == 0) return;
 
-            // construct a new watcher, and put it in the map
-            _watchers[fd] = std::unique_ptr<Watcher>(new Watcher(_loop, connection, fd, flags));
+            // construct a new watcher, and register as active
+            _watchers[fd] =
+#if __cplusplus >= 201402L
+            // C++14 has make_unique()
+                std::make_unique<Watcher>(_loop, connection, _connection_timeout, fd, flags);
+#else
+                std::unique_ptr<Watcher>(new Watcher(_loop, connection, _connection_timeout, fd, flags));
+#endif
+            auto &upwatcher = _watchers[fd];
+
+            // apply server connection timeout monitor
+            upwatcher->apply_connection_timeout();
+
+            // explicitly set the events to monitor
+            upwatcher->set_event_mask(flags);
         }
         else if (flags == 0)
         {
-            // the watcher does already exist, but we no longer have to watch this watcher
+            // the watcher does not need anymore, unregister
             _watchers.erase(iter);
         }
         else
         {
-            // change the events
-            iter->second->events(flags);
+            // reconfigure the events to monitor
+            iter->second->set_event_mask(flags);
         }
     }
 
+protected:
+
+    /**
+     *  Method that is called when the heartbeat frequency is negotiated.
+     *  @param  connection      The connection that suggested a heartbeat timeout
+     *  @param  timeout         The suggested timeout from the server (seconds)
+     *  @return uint16_t        The timeout to use
+     */
+    uint16_t onNegotiate(TcpConnection *connection, uint16_t timeout) override
+    {
+        // skip if no heartbeats are needed
+        if (timeout == 0) return 0;
+
+        const int fd = connection->fileno();
+
+        auto iter = _watchers.find(fd);
+        assert(iter != _watchers.end()); // a watcher must exist when negotiating the heartbeat
+
+        // apply heartbeat monitor
+        iter->second->set_heartbeat(timeout);
+        iter->second->set_timer();
+
+        // we agree with the timeout
+        return timeout;
+    }
+
 public:
+
     /**
      *  Constructor
      *  @param  loop    The event loop to wrap
      */
-    LibUvHandler(uv_loop_t *loop) : _loop(loop) {}
+    LibUvHandler(uv_loop_t *loop, uint16_t connection_timeout = 60)
+        : _loop(loop), _connection_timeout(connection_timeout)
+    {
+        // TODO: make AMQP::readable AMQP::writable (and other flags) constexpr,
+        //       then switch to static_assert and get rid of these
+        assert(AMQP::readable == UV_READABLE);
+        assert(AMQP::writable == UV_WRITABLE);
+    }
+
+    /**
+     *  Handler cannot be copied or moved
+     *
+     *  @param  that    The object to not move or copy
+     */
+    LibUvHandler(LibUvHandler &&that) = delete;
+    LibUvHandler(const LibUvHandler &that) = delete;
 
     /**
      *  Destructor
@@ -222,3 +503,4 @@ public:
  *  End of namespace
  */
 }
+


### PR DESCRIPTION
As I did for the `LibBoostAsioHandler`, I also completely rewrote the `LibUvHandler`, and the related test example code.

The new handler is perfectly in line with those of `libboostasio` and `libev`, in terms of implemented features and reliability. After all, those are the inspirations.

This definitely fixes #516 as the heartbeat now works, and #491 is probably fixed as well.  Among the peculiar characteristics of this handler there is certainly speed. At the end, native Libuv is polling.

I'm making this version of the handler available here, along with the example test, for anyone who wants to try it out in advance or take a look inside.
> [!IMPORTANT]
> [**libuv_2025-12-20.zip**](https://github.com/user-attachments/files/24268846/libuv_2025-12-20.zip)

@ogapo, I hope you don't mind, but your implementation was way behind the times.