### PR TITLE
libevent fully refactored

### DIFF
--- a/examples/libevent.cpp
+++ b/examples/libevent.cpp
@@ -1,17 +1,315 @@
-/**
- *  Libevent.cpp
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
  *
- *  Test program to check AMQP functionality based on Libevent
+ * Copyright 2025 Copernica BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
+ *  LibEvent.cpp
+ *
+ *  Test program to check AMQP functionality based on libevent.
+ *
+ *  Compile with (append -lssl if #define USE_AMQPS):
+ *  g++ -std=c++17 -Wall -Wno-class-conversion libevent.cpp -o libevent -levent -lamqpcpp -lpthread -ldl
  *
  *  @author Brent Dimmig <brentdimmig@gmail.com>
+ *  @author Paolo Pastori
  */
+
+/*
+ * uncomment (and link with -lssl) to use amqps instead of plain amqp
+ */
+//#define USE_AMQPS
 
 /**
  *  Dependencies
  */
+#include <signal.h>
 #include <event2/event.h>
+#ifdef USE_AMQPS
+#include <openssl/ssl.h>
+#include <openssl/opensslv.h>
+#endif // USE_AMQPS
+#include <iomanip>
+
 #include <amqpcpp.h>
 #include <amqpcpp/libevent.h>
+
+
+/**
+ *  Class that runs a timer
+ */
+class MyTimer
+{
+private:
+    /**
+     *  The timer event structure
+     *  @var struct event
+     */
+    struct event *_timer;
+
+    /**
+     *  The AMQP channel
+     *  @var AMQP::TcpChannel
+     */
+    AMQP::TcpChannel *_pchannel;
+
+    /**
+     *  Name of the queue
+     *  @var std::string
+     */
+    std::string _queue;
+
+    /**
+     *  Callback method that is called by libevent when a timeout elapses
+     *  @param  fd      The filedescriptor associated (usually -1)
+     *  @param  what    Events triggered (always EV_TIMEOUT)
+     *  @param  arg     (void *) this
+     */
+    static void callback(int fd, short what, void *arg)
+    {
+        // counter for published messages
+        static uint32_t pno = 0;
+
+        // retrieve this
+        MyTimer *self = static_cast<MyTimer*>(arg);
+
+        // reschedule the timer with a new timeout
+        struct timeval tmout = { 1, 0 };   // periodical delay
+        event_add(self->_timer, &tmout);
+
+        // publish a message
+        self->_pchannel->publish("", self->_queue, "Hello World");
+
+        std::cout << "message " << ++pno << " published" << std::endl;
+    }
+
+public:
+    /**
+     *  Constructor
+     *  @param  base     The event loop
+     *  @param  channel  The channel to use
+     *  @param  queue    The name of the queue to use
+     */
+    MyTimer(struct event_base *base, AMQP::TcpChannel *channel, std::string queue) :
+        _pchannel(channel), _queue(queue)
+    {
+        // initialize the timer event
+        _timer = event_new(base, -1, EV_PERSIST, callback, this);
+
+        // makes the timer pending (start)
+        struct timeval tmout = { 5, 0 };   // intial delay
+        event_add(_timer, &tmout);
+    }
+
+    /**
+     *  Destructor
+     */
+    ~MyTimer()
+    {
+        // deallocate the timer event
+        event_free(_timer);
+    }
+};
+
+
+/**
+ *  Custom handler
+ */
+class MyHandler : public AMQP::LibEventHandler
+{
+private:
+    /**
+     *  Method that is called when a connection error occurs
+     *  @param  connection  The TCP connection
+     *  @param  message     The error message
+     */
+    void onError(AMQP::TcpConnection* /* connection */, const char *message) override
+    {
+        std::cout << "error: " << std::quoted(message) << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection ends up in a connected state
+     *  @param  connection  The TCP connection
+     */
+    void onConnected(AMQP::TcpConnection *connection) override
+    {
+        std::cout << "connected\n";
+
+        // save the connection to close and start the signal
+        _conn_to_close = connection;
+        event_add(_signal, nullptr);
+
+        std::cout << "\n  Hit CTRL-C to exit\n" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection ends up in a ready
+     *  @param  connection  The TCP connection
+     */
+    void onReady(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "ready" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is closed
+     *  @param  connection  The TCP connection
+     */
+    void onClosed(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "closed" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection was blocked
+     *  @param  connection      The connection that was blocked
+     *  @param  reason          Why was the connection blocked
+     */
+    void onBlocked(AMQP::TcpConnection* /* connection */, const char *reason) override
+    {
+        std::cout << "blocked with reason " << std::quoted(reason) << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is no longer blocked
+     *  @param  connection      The connection that is no longer blocked
+     */
+    void onUnblocked(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "unblocked" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is lost or closed
+     *  @param  connection  The TCP connection
+     */
+    void onLost(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "lost" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is detached
+     *  @param  connection  The TCP connection
+     */
+    void onDetached(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "detached" << std::endl;
+    }
+
+
+    /**
+     *  The signal event structure to be used for process termination
+     *  @var uv_signal_t
+     */
+    struct event *_signal;
+
+    /**
+     *  The connection to be closed when pressing CTRL-C
+     *  @var TcpConnection
+     */
+    AMQP::TcpConnection *_conn_to_close = nullptr;
+
+    /**
+     *  The timer used for periodical publishing
+     *  @var MyTimer
+     */
+    MyTimer *_mytimer = nullptr;
+
+    /**
+     * Callback method that is called by libuv when a signal is catched
+     * @param  signo   The catched signal
+     * @param  what    Events triggered (always EV_SIGNAL)
+     * @param  arg     (void *) this
+     */
+    static void sig_callabck(int signo, short what, void *arg)
+    {
+        // retrieve this
+        MyHandler *self = static_cast<MyHandler*>(arg);
+
+        if (self->_conn_to_close) {
+
+            std::cerr << "\nclosing connection...\n";
+            // now we gently close the connection
+            self->_conn_to_close->close();
+
+            // NOTE: we have to empty the event loop before leave
+            //       otherwise the process will hang
+            event_del(self->_signal);
+            self->stop_timer();
+        }
+    }
+
+public:
+
+    /**
+     *  Constructor
+     *  @param  base  The event loop
+     */
+    MyHandler(struct event_base *base) : AMQP::LibEventHandler(base)
+    {
+        // initialize the signal event
+        _signal = evsignal_new(base, SIGINT, sig_callabck, this);
+    }
+
+    /**
+     *  Install the user timer
+     */
+    void set_timer(MyTimer *timer)
+    {
+        _mytimer = timer;
+    }
+
+    /**
+     *  Stop the timer
+     */
+    void stop_timer()
+    {
+        if (_mytimer)
+        {
+            delete _mytimer;
+            _mytimer = nullptr;
+        }
+    }
+
+    /**
+     *  Stop listening for signals
+     */
+    void stop_signals()
+    {
+        event_del(_signal);
+    }
+
+    /**
+     *  Destructor
+     */
+    virtual ~MyHandler()
+    {
+        // deallocate the signal event
+        event_free(_signal);
+
+        stop_timer();
+    }
+};
 
 
 /**
@@ -20,34 +318,87 @@
  */
 int main()
 {
-    // access to the event loop
-    auto evbase = event_base_new();
+    // the event loop
+    auto *base = event_base_new();
 
-    // handler for libevent
-    AMQP::LibEventHandler handler(evbase);
+    // the handler
+    MyHandler handler(base);
+
+#ifdef USE_AMQPS
+    // init the SSL library
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_library_init();
+#else
+    OPENSSL_init_ssl(0, NULL);
+#endif
+
+    AMQP::Address address("amqps://guest:guest@localhost/");
+#else
+    AMQP::Address address("amqp://guest:guest@localhost/");
+#endif // USE_AMQPS
 
     // make a connection
-    AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://localhost/"));
+    AMQP::TcpConnection connection(&handler, address);
 
-    // we need a channel too
+    // make a channel
     AMQP::TcpChannel channel(&connection);
 
     // create a temporary queue
-    channel.declareQueue(AMQP::exclusive).onSuccess([&connection](const std::string &name, uint32_t messagecount, uint32_t consumercount) {
+    channel.declareQueue(AMQP::exclusive)
+      .onSuccess([&connection, &channel, &handler, base](const std::string &queuename, uint32_t messagecount, uint32_t consumercount) {
 
-        // report the name of the temporary queue
-        std::cout << "declared queue " << name << std::endl;
+        std::cout << "declared queue " << std::quoted(queuename) << std::endl;
 
-        // now we can close the connection
-        connection.close();
+/*        // close the channel
+        channel.close().onSuccess([&connection, &handler]() {
+
+            std::cout << "channel closed" << std::endl;
+
+            // close the connection
+            connection.close();
+
+            // NOTE: we have to empty the event loop before leave
+            //       otherwise the process will hang
+            handler.stop_signals();
+
+        }); */
+
+        // start a consumer
+        channel.consume(queuename).onReceived([&channel, queuename](const AMQP::Message &message, uint64_t deliveryTag, bool redelivered) {
+
+            std::cout << "received " << deliveryTag << std::endl;
+
+/*            // we remove the queue, to see if this indeed triggers the onCancelled method
+            if (deliveryTag > 4) channel.removeQueue(queuename); */
+
+            // ack the message
+            channel.ack(deliveryTag);
+
+        }).onSuccess([&handler, base, &channel, queuename](const std::string &tag) {
+
+            // the consumer is ready
+            std::cout << "started consuming with tag " << std::quoted(tag) << std::endl;
+
+            // start the publisher too
+            handler.set_timer(new MyTimer(base, &channel, queuename));
+
+        }).onCancelled([&handler](const std::string &tag) {
+
+            // the consumer was cancelled by the server
+            std::cout << "consumer " << std::quoted(tag) << " was cancelled" << std::endl;
+
+            // stop the publisher
+            handler.stop_timer();
+
+        });
     });
 
-    // run the loop
-    event_base_dispatch(evbase);
+    // run the event loop
+    event_base_dispatch(base);
 
-    event_base_free(evbase);
+    // deallocate the loop
+    event_base_free(base);
 
-    // done
     return 0;
 }
 

--- a/include/amqpcpp/libevent.h
+++ b/include/amqpcpp/libevent.h
@@ -1,13 +1,36 @@
-/**
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
+ *
+ * Copyright 2025 Copernica BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
  *  LibEvent.h
  *
  *  Implementation for the AMQP::TcpHandler that is optimized for libevent. You can
  *  use this class instead of a AMQP::TcpHandler class, just pass the event loop
- *  to the constructor and you're all set
+ *  to the constructor and you're all set.  See examples/libevent.cpp for an example.
  *
- *  Compile with: "g++ -std=c++11 libevent.cpp -lamqpcpp -levent -lpthread"
  *
  *  @author Brent Dimmig <brentdimmig@gmail.com>
+ *  @author Paolo Pastori
  */
 
 /**
@@ -19,8 +42,20 @@
  *  Dependencies
  */
 #include <event2/event.h>
-#include <amqpcpp/flags.h>
-#include <amqpcpp/linux_tcp.h>
+#if __cplusplus >= 201402L
+// >= C++14, using make_unique
+#include <memory>
+#endif
+#include <map>
+#include <cassert>
+
+#include "amqpcpp/linux_tcp.h"
+
+
+// TODO: maybe for AMQP-CPP VERSION > 4.3.27 we can use
+//       these in place of the assert placed into ctor
+//static_assert(AMQP::readable == (EV_READ >> 1), "libevent vs AMQP-CPP flags mismatch");
+//static_assert(AMQP::writable == (EV_WRITE >> 1), "libevent vs AMQP-CPP flags mismatch");
 
 /**
  *  Set up namespace
@@ -34,127 +69,317 @@ class LibEventHandler : public TcpHandler
 {
 private:
     /**
-     *  Helper class that wraps a libev I/O watcher
+     *  Helper class that wraps a libevent I/O watcher
      */
     class Watcher
     {
     private:
         /**
-         *  The actual event structure
+         *  The connection being watched
+         *  @var TcpConnection
+         */
+        TcpConnection *_connection;
+
+        /**
+         *  The event loop to which it is attached
+         *  @var struct event_base
+         */
+        struct event_base *_base;
+
+        /**
+         *  The io event structure
          *  @var struct event
          */
-        struct event * _event;
+        struct event *_io;
+
+        /**
+         *  The timer event structure
+         *  @var struct event
+         */
+        struct event *_timer;
+
+        /**
+         *  AMQP Server connection timeout setting (seconds)
+         *  @var uint16_t
+         */
+        uint16_t _connection_timeout = 0;
+
+        /**
+         *  Timeout after which the connection is no longer considered alive.
+         *  A heartbeat must be sent every _timeout / 2 seconds.
+         *  Value zero means heartbeats are disabled, or not yet negotiated.
+         *  @var uint16_t
+         */
+        uint16_t _timeout = 0;
+
+        /**
+         *  When should we send the next heartbeat?
+         *  @var struct timeval
+         */
+        struct timeval _next;
+
+        /**
+         *  When does the connection expire / was the server idle for too long?
+         *  @var struct timeval
+         */
+        struct timeval _expire;
+
+        /**
+         *  The events for which the filedescriptor is actually monitored.
+         *  @var int
+         */
+        int _events = 0;
+
+        /**
+         *  Helper method to check for connection socket status
+         *  @return bool
+         */
+        bool is_open()
+        {
+            return (_connection->fileno() != -1);
+        }
 
         /**
          *  Callback method that is called by libevent when a filedescriptor becomes active
-         *  @param  fd                   The filedescriptor with an event
-         *  @param  what                 Events triggered
-         *  @param  connection_arg       void * to the connection
+         *  @param  fd      The filedescriptor with an event
+         *  @param  what    Events triggered
+         *  @param  arg     (void *) this
          */
-        static void callback(evutil_socket_t fd, short what, void *connection_arg)
+        static void io_callback(int fd, short what, void *arg)
         {
-            // retrieve the connection
-            TcpConnection *connection = static_cast<TcpConnection*>(connection_arg);
+            Watcher* self = static_cast<Watcher*>(arg);
 
-            // setup amqp flags
-            int amqp_flags = 0;
-            if (what & EV_READ)
-                amqp_flags |= AMQP::readable;
-            if (what & EV_WRITE)
-                amqp_flags |= AMQP::writable;
+            // is the socket still open?
+            if (self->is_open())
+            {
+                struct timeval now, delta;
+                event_base_gettimeofday_cached(self->_base, &now);
 
-            // tell the connection that its filedescriptor is active
-            connection->process(fd, amqp_flags);
+                // setup flags
+                int events = (what >> 1) & (AMQP::writable | AMQP::readable);
+
+                if (events & AMQP::readable)
+                {
+                    // the server is sending data, update the _expire time
+                    delta = { self->_timeout + (self->_timeout >> 1), 500'000 };
+                    evutil_timeradd(&now, &delta, &self->_expire);
+                }
+                if (events & AMQP::writable)
+                {
+                    // the client is sending data, update the _next time
+                    delta = { self->_timeout >> 1, 500'000 };
+                    evutil_timeradd(&now, &delta, &self->_next);
+                }
+
+                self->_connection->process(fd, events);
+            }
+        }
+
+        /**
+         *  Callback method that is called by libevent when a timeout elapses
+         *  @param  fd      The filedescriptor associated
+         *  @param  what    Events triggered (always EV_TIMEOUT)
+         *  @param  arg     (void *) this
+         */
+        static void timer_callback(int fd, short what, void *arg)
+        {
+            Watcher* self = static_cast<Watcher*>(arg);
+
+            // is the socket still open?
+            if (self->is_open())
+            {
+                struct timeval now;
+                event_base_gettimeofday_cached(self->_base, &now);
+
+                if (self->_timeout == 0)
+                {
+                    // this can happen in three situations:
+                    // 1. a connection timeout,
+                    // 2. user space has overidden onNegotiate to reject heartbeats
+                    // 3. AMQP server does not want heartbeats
+                    // in either case we're no longer going to run further timers.
+
+                    // if we have an initialized connection, user space must have overidden
+                    // the onNegotiate method, so we keep using the connection
+                    if (self->_connection->initialized()) return;
+
+                    // this is a connection timeout, close the connection with immediate effect
+                    return (void) self->_connection->close(true);
+                }
+                else if (evutil_timercmp(&now, &self->_expire, >=))
+                {
+                    // the server was inactive for a too long period of time,
+                    // close the connection with immediate effect
+                    self->_timeout = 0;
+                    return (void) self->_connection->close(true);
+                }
+                else if (evutil_timercmp(&now, &self->_next, >=))
+                {
+                    // send the heartbeat
+                    self->_connection->heartbeat();
+
+                    // when we should send out the next one
+                    struct timeval delta = { self->_timeout >> 1, 500'000 };
+                    evutil_timeradd(&now, &delta, &self->_next);
+                }
+            }
         }
 
     public:
+
         /**
          *  Constructor
-         *  @param  evbase          The current event loop
-         *  @param  connection      The connection being watched
-         *  @param  fd              The filedescriptor being watched
-         *  @param  events          The events that should be monitored
+         *  @param  base                The current event loop
+         *  @param  connection          The connection being watched
+         *  @param  connection_timeout  The AMQP server connection timeout
+         *  @param  fd                  The filedescriptor being watched
+         *  @param  events              The events that should be monitored
          */
-        Watcher(struct event_base *evbase, TcpConnection *connection, int fd, int events)
+        Watcher(struct event_base *base,
+                TcpConnection *connection,
+                uint16_t connection_timeout,
+                int fd,
+                int events) :
+            _connection(connection), _base(base), _connection_timeout(connection_timeout)
         {
-            // setup libevent flags
+            // initialize the io event
             short event_flags = EV_PERSIST;
-            if (events & AMQP::readable)
-                event_flags |= EV_READ;
-            if (events & AMQP::writable)
-                event_flags |= EV_WRITE;
+            if (events & AMQP::readable) event_flags |= EV_READ;
+            if (events & AMQP::writable) event_flags |= EV_WRITE;
 
-            // initialize the event
+            _io = event_new(base, fd, event_flags, io_callback, this);
 
-            _event = event_new(evbase, fd, event_flags, callback, connection);
-            event_add(_event, nullptr);
+            // makes it pending (start)
+            event_add(_io, nullptr);
+
+            // remember current event mask
+            _events = events;
+
+            // initialize the timer event
+            _timer = event_new(base, fd, EV_PERSIST, timer_callback, this);
         }
+
+        /**
+         *  Watchers cannot be copied or moved
+         *
+         *  @param  that    The object to not move or copy
+         */
+        Watcher(Watcher &&that) = delete;
+        Watcher(const Watcher &that) = delete;
 
         /**
          *  Destructor
          */
         virtual ~Watcher()
         {
-            // stop the event
-            event_del(_event);
-            // free the event
-            event_free(_event);
+            // deallocate the io event
+            event_free(_io);
+            // deallocate the timer event
+            event_free(_timer);
         }
 
         /**
-         *  Change the events for which the filedescriptor is monitored
-         *  @param  events
+         *  Set the events for which the filedescriptor is monitored
+         *  @param  events  The events to monitor (readable, writable or both)
          */
-        void events(int events)
+        void set_event_mask(int events)
         {
-            // stop the event if it was active
-            event_del(_event);
+            if (events != _events)
+            {
+                // make the event non pending (stop)
+                event_del(_io);
 
-            // setup libevent flags
-            short event_flags = EV_PERSIST;
-            if (events & AMQP::readable)
-                event_flags |= EV_READ;
-            if (events & AMQP::writable)
-                event_flags |= EV_WRITE;
+                // setup libevent flags
+                short event_flags = EV_PERSIST | static_cast<short>(events << 1);
 
-            // set the events
-            event_assign(_event, event_get_base(_event), event_get_fd(_event), event_flags,
-                         event_get_callback(_event), event_get_callback_arg(_event));
+                // set the events
+                event_assign(_io, _base, event_get_fd(_io), event_flags,
+                             io_callback, this);
 
-            // and restart it
-            event_add(_event, nullptr);
+                // makes it pending (start)
+                event_add(_io, nullptr);
+
+                // remember current event mask
+                _events = events;
+            }
+        }
+
+        /**
+         *  Apply AMQP server connection timeout watching
+         */
+        void apply_connection_timeout()
+        {
+            if (_connection_timeout && !_timeout)
+            {
+                // makes the timer pending (start)
+                struct timeval delta = { _connection_timeout, 0 };
+                event_add(_timer, &delta);
+            }
+        }
+
+        /**
+         *  Configure the heartbeat interval to use
+         *  @param timeout  The timeout value (seconds, 0 to disable heartbeat monitor.)
+         */
+        void set_heartbeat(uint16_t timeout)
+        {
+            _timeout = timeout;
+        }
+
+        /**
+         *  Schedule the timer
+         */
+        void set_timer()
+        {
+            // stop timer in case it was already set
+            stop_timer();
+
+            if (_timeout)
+            {
+                struct timeval now;
+                event_base_gettimeofday_cached(_base, &now);
+
+                // when we should send out the next one
+                struct timeval delta = { _timeout >> 1, 500'000 };
+                evutil_timeradd(&now, &delta, &_next);
+
+                // the server is sending data, update the _expire time
+                struct timeval deltb = { _timeout, 0 };
+                evutil_timeradd(&_next, &deltb, &_expire);
+
+                // makes the timer pending (start)
+                event_add(_timer, &delta);
+            }
+        }
+
+        /**
+         *  Stop the timer
+         */
+        void stop_timer()
+        {
+            // make the event non pending (stop)
+            // do nothing if it was never set
+            event_del(_timer);
         }
     };
-
 
     /**
      *  The event loop
      *  @var struct event_base*
      */
-    struct event_base *_evbase;
+    struct event_base *_base;
 
     /**
      *  All I/O watchers that are active, indexed by their filedescriptor
      *  @var std::map<int,Watcher>
      */
-    std::map<int,std::unique_ptr<Watcher>> _watchers;
-
+    std::map<int, std::unique_ptr<Watcher>> _watchers;
 
     /**
-     *  Method that is called when the heartbeat frequency is negotiated
-     *  @param  connection      The connection that suggested a heartbeat interval
-     *  @param  interval        The suggested interval from the server
-     *  @return uint16_t        The interval to use
+     *  AMQP Server connection timeout setting (seconds)
+     *  @var uint16_t
      */
-    virtual uint16_t onNegotiate(TcpConnection *connection, uint16_t interval) override
-    {
-        // call base (in the highly theoretical case that the base class does something meaningful)
-        auto response = TcpHandler::onNegotiate(connection, interval);
-        
-        // because the LibEvHandler has not yet implemented timers for ensuring that we send
-        // some data every couple of seconds, we disabled timeouts
-        return 0;
-    }
+    uint16_t _connection_timeout;
 
     /**
      *  Method that is called by AMQP-CPP to register a filedescriptor for readability or writability
@@ -170,30 +395,85 @@ private:
         // was it found?
         if (iter == _watchers.end())
         {
-            // we did not yet have this watcher - but that is ok if no filedescriptor was registered
+            // a new watcher is required
+
+            // skip if no read/write activity to monitor
             if (flags == 0) return;
 
-            // construct a new watcher, and put it in the map
-            _watchers[fd] = std::unique_ptr<Watcher>(new Watcher(_evbase, connection, fd, flags));
+            // construct a new watcher, and register as active
+            _watchers[fd] =
+#if __cplusplus >= 201402L
+            // C++14 has make_unique()
+                std::make_unique<Watcher>(_base, connection, _connection_timeout, fd, flags);
+#else
+                std::unique_ptr<Watcher>(new Watcher(_base, connection, _connection_timeout, fd, flags));
+#endif
+            auto &upwatcher = _watchers[fd];
+
+            // apply server connection timeout monitor
+            upwatcher->apply_connection_timeout();
         }
         else if (flags == 0)
         {
-            // the watcher does already exist, but we no longer have to watch this watcher
+            // the watcher does not need anymore, unregister
             _watchers.erase(iter);
         }
         else
         {
-            // change the events
-            iter->second->events(flags);
+            // reconfigure the events to monitor
+            iter->second->set_event_mask(flags);
         }
     }
 
+protected:
+
+    /**
+     *  Method that is called when the heartbeat frequency is negotiated.
+     *  @param  connection      The connection that suggested a heartbeat timeout
+     *  @param  timeout         The suggested timeout from the server
+     *  @return uint16_t        The timeout to use
+     */
+    virtual uint16_t onNegotiate(TcpConnection *connection, uint16_t timeout) override
+    {
+        // skip if no heartbeats are needed
+        if (timeout == 0) return 0;
+
+        const int fd = connection->fileno();
+
+        auto iter = _watchers.find(fd);
+        assert(iter != _watchers.end()); // a watcher must exist when negotiating the heartbeat
+
+        // apply heartbeat monitor
+        iter->second->set_heartbeat(timeout);
+        iter->second->set_timer();
+
+        // we agree with the timeout
+        return timeout;
+    }
+
 public:
+
     /**
      *  Constructor
-     *  @param  evbase  The event loop to wrap
+     *  @param  base                The event loop to wrap
+     *  @param  connection_timeout  The AMQP server connection timeout (seconds)
      */
-    LibEventHandler(struct event_base *evbase) : _evbase(evbase) {}
+    LibEventHandler(struct event_base *base, uint16_t connection_timeout = 60)
+        : _base(base), _connection_timeout(connection_timeout)
+    {
+        // TODO: make AMQP::readable AMQP::writable (and other flags) constexpr,
+        //       then switch to static_assert and get rid of these
+        assert(AMQP::readable == (EV_READ >> 1));
+        assert(AMQP::writable == (EV_WRITE >> 1));
+    }
+
+    /**
+     *  Handler cannot be copied or moved
+     *
+     *  @param  that    The object to not move or copy
+     */
+    LibEventHandler(LibEventHandler &&that) = delete;
+    LibEventHandler(const LibEventHandler &that) = delete;
 
     /**
      *  Destructor
@@ -205,3 +485,4 @@ public:
  *  End of namespace
  */
 }
+


### PR DESCRIPTION
As I did for the `LibBoostAsioHandler` and the `LibUvHandler`, now it's time for `LibEventHandler` too.

This version implements heartbeat and offers the same functionality as the other handlers (finally a fix for #330.) The example code has also been updated to do exactly the same things as the other examples.

This will allow for quick comparisons between different handlers, in terms of usage and perhaps benchmarking. Certainly, if you encounter problems with a handler, you can now quickly check whether changing handler solves the problem.

I don't think I could give a better Christmas present to AMQP-CPP, which can finally boast a large selection of handlers, all fully functional. Although I shouldn't say anything about libev...

I must confess that at the underlying library level, `libevent` left me pleasantly impressed and I recommend it for its ease of use, the richness of its APIs and the truly complete documentation it has.

As usual, for those impatient and eager to try it, here it is.

> [!IMPORTANT]
> [**libevent_2025-12-20.zip**](https://github.com/user-attachments/files/24272222/libevent_2025-12-20.zip)

@brentnd I hope you don't mind me brushing up your code, but it was about time.