### PR TITLE
Refactoring libboostasio (part 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ channel2.declareExchange("my-exchange");
 
 Now, if an error occurs with declaring the queue, it will not have consequences
 for the other call. But this comes at a small price: setting up the extra channel
-requires and extra instruction to be sent to the RabbitMQ server, so some extra
+requires an extra instruction to be sent to the RabbitMQ server, so some extra
 bytes are sent over the network, and some additional resources in both the client
 application and the RabbitMQ server are used (although this is all very limited).
 
@@ -1097,7 +1097,7 @@ bool publish(const std::string &exchange, const std::string &routingKey, const c
 Published messages are normally not confirmed by the server, and the RabbitMQ
 will not send a report back to inform you whether the message was successfully
 published or not. But with the flags you can instruct RabbitMQ to send back
-the message if it was undeliverable. In you use these flags you must also install
+the message if it was undeliverable. If you use these flags you must also install
 callbacks that will process these bounced messages.
 
 You can also use transactions to ensure that your messages get delivered.
@@ -1146,7 +1146,7 @@ the server starts counting the received messages (starting from 1) and sends
 acknowledgments for every message it processed (it can also acknowledge 
 multiple message at once). 
 
-If server is unable to process a message, it will send send negative 
+If server is unable to process a message, it will send negative 
 acknowledgments. Both positive and negative acknowledgments handling are 
 passed to callbacks that you can install on the object that
 is returned by the `confirmSelect()` method:
@@ -1190,7 +1190,7 @@ operations are individually acknowledged:
 // create a channel
 AMQP::TcpChannel mychannel(connection);
 
-// wrap the channel into a reliable-object so that publish-opertions are
+// wrap the channel into a reliable-object so that publish-operations are
 // individually confirmed (after wrapping the channel, it is recommended
 // to no longer make direct calls to the channel)
 AMQP::Reliable reliable(mychannel);
@@ -1289,7 +1289,7 @@ for (size_t i = 0; i < 100000; ++i)
 }
 ````
 
-For more information, see http://www.rabbitmq.com/confirms.html.
+For more information, see http://www.rabbitmq.com/docs/confirms.
 
 CONSUMING MESSAGES
 ==================

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ to RabbitMQ has to be set up.
 
 An example compilation command for an application using the TCP module:
 ```bash
-g++ -g -Wall -lamqcpp -lpthread -ldl my-amqp-cpp.c -o my-amqp-cpp
+g++ -std=c++17 -g -Wall -lamqcpp -lpthread -ldl my-amqp-cpp.c -o my-amqp-cpp
 ```
 
 HOW TO USE AMQP-CPP
@@ -710,7 +710,7 @@ it has a couple of open issues.
 
 | TCP Handler Impl        | Header File Location   |  Sample File Location     |
 | ----------------------- | ---------------------- | ------------------------- |
-| Boost asio (io_service) | include/libboostasio.h | examples/libboostasio.cpp |  
+| Boost asio              | include/libboostasio.h | examples/libboostasio.cpp |
 | libev                   | include/libev.h        | examples/libev.cpp        |
 | libevent                | include/libevent.h     | examples/libevent.cpp     |
 | libuv                   | include/libuv.h        | examples/libuv.cpp        |
@@ -770,7 +770,7 @@ class MyTcpHandler : public AMQP::TcpHandler
 ````
 
 If you enable heartbeats, it is your own responsibility to ensure that the
-```connection->heartbeat()``` method is called at least once during this period,
+`connection->heartbeat()` method is called at least once during this period,
 or that you call one of the other channel or connection methods to send data
 over the connection. Heartbeats are sent by the server too, RabbitMQ also ensures
 that _some data_ is sent over the connection from the server to the client 

--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -1,7 +1,7 @@
 /**
  *  LibBoostAsio.cpp
  *
- *  Test program to check AMQP functionality based on Boost's asio io_service.
+ *  Test program to check AMQP functionality based on Boost's asio io_context.
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
  *

--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -35,7 +35,7 @@
 /*
  * uncomment (and link with -lssl) to use amqps instead of plain amqp
  */
-#define USE_AMQPS
+//#define USE_AMQPS
 
 /**
  *  Dependencies
@@ -63,16 +63,10 @@ class MyTimer
 {
 private:
     /**
-     *  The actual timer
+     *  The asynchronous timer
      *  @var boost::asio::steady_timer
      */
     boost::asio::steady_timer _timer;
-
-    /**
-     *  The counter for published messages
-     *  @var uint16_t
-     */
-    uint16_t _pno = 0;
 
 protected:
     /**
@@ -83,10 +77,13 @@ protected:
     {
         if (!ec && pchannel)
         {
+            // counter for published messages
+            static uint32_t pno = 0;
+
             // publish a message
             pchannel->publish("", queue, "Hello World");
 
-            std::cout << "message " << ++_pno << " published" << std::endl;
+            std::cout << "message " << ++pno << " published" << std::endl;
 
             // reschedule
             start();
@@ -101,7 +98,7 @@ public:
     uint16_t milli_seconds = 1000;
 
     /**
-     *  Pointer towards the AMQP channel
+     *  The AMQP channel
      *  @var AMQP::TcpChannel
      */
     AMQP::TcpChannel *pchannel;
@@ -191,6 +188,7 @@ private:
         // install the signals handler
         _signals.async_wait([this, connection](const boost_errc& ec, int /* signal_number */) {
             if (!ec) {
+
                 // now we gently close the connection
                 std::cerr << "\nclosing connection...\n";
 
@@ -282,7 +280,7 @@ protected:
      */
     uint16_t onNegotiate(AMQP::TcpConnection *connection, uint16_t interval) override
     {
-        // could override server proposed interval here, i.e.
+        // could override server proposed interval here, e.g.
         // uncoment to force interval 0 to suppress heartbeat
         //interval = 0;
 
@@ -370,7 +368,7 @@ int main()
     channel.declareQueue(AMQP::exclusive)
       .onSuccess([&connection, &channel, &timer, &handler](const std::string &queuename, uint32_t messagecount, uint32_t consumercount) {
 
-        std::cout << "declared queue " << quoted(queuename) << std::endl;
+        std::cout << "declared queue " << std::quoted(queuename) << std::endl;
 
         timer.queue = queuename;
 
@@ -402,7 +400,7 @@ int main()
         }).onSuccess([&timer](const std::string &tag) {
 
             // the consumer is ready
-            std::cout << "started consuming with tag " << quoted(tag) << std::endl;
+            std::cout << "started consuming with tag " << std::quoted(tag) << std::endl;
 
             // start the publisher too
             timer.start();
@@ -410,32 +408,12 @@ int main()
         }).onCancelled([&timer](const std::string &tag) {
 
             // the consumer was cancelled by the server
-            std::cout << "consumer " << quoted(tag) << " was cancelled" << std::endl;
+            std::cout << "consumer " << std::quoted(tag) << " was cancelled" << std::endl;
 
             // stop the publisher
             timer.stop();
-
-        }).onError([&timer, &connection, &handler](const char *message) {
-
-            // the consumer was cancelled by the server
-            std::cout << "consumer operation failed" << std::endl;
-
-            // stop the publisher
-            timer.stop();
-
-            // close the connection
-            connection.close();
-
-            // NOTE: there must be no callabacks queued in execution
-            //       context otherwise the process will hang
-            handler.stop_signals();
 
         });
-
-/*        // close the connection
-        connection.close();
-        // NOTE: this will have no effect, as the timer is not started yet
-        timer.stop(); */
     });
 
     // run the handler

--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -1,20 +1,19 @@
 /**
  *  LibBoostAsio.cpp
- * 
+ *
  *  Test program to check AMQP functionality based on Boost's asio io_service.
- * 
+ *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
  *
- *  Compile with g++ -std=c++14 libboostasio.cpp -o boost_test -lpthread -lboost_system -lamqpcpp
+ *  Compile with:
+ *  g++ -std=c++17 -Wall  libboostasio.cpp -o boost_test  -lboost_system -lamqpcpp -lpthread -ldl
  */
 
 /**
  *  Dependencies
  */
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/strand.hpp>
-#include <boost/asio/deadline_timer.hpp>
-
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
 
 #include <amqpcpp.h>
 #include <amqpcpp/libboostasio.h>
@@ -25,32 +24,51 @@
  */
 int main()
 {
-
     // access to the boost asio handler
-    // note: we suggest use of 2 threads - normally one is fin (we are simply demonstrating thread safety).
-    boost::asio::io_service service(4);
+    boost::asio::io_context context;
 
-    // handler for libev
-    AMQP::LibBoostAsioHandler handler(service);
-    
+    // set of signal for process termination (CTRL-C, kill)
+    boost::asio::signal_set signals(context, SIGINT, SIGTERM);
+
+    // handler for libboostasio
+    AMQP::LibBoostAsioHandler handler(context);
+
     // make a connection
     AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://guest:guest@localhost/"));
-    
+
     // we need a channel too
     AMQP::TcpChannel channel(&connection);
-    
+
+    channel.onReady([&signals, &connection]() {
+        std::cout << "hit CTRL-C to exit\n\nchannel ready\n";
+
+        // install the signals handler
+        signals.async_wait([&connection](const boost::system::error_code& ec, int /* signal_number */)
+        {
+            if (!ec) {
+                // now we gently close the connection
+                std::cerr << "\nclosing connection...\n";
+                connection.close();
+            }
+        });
+    });
+    channel.onError([](const char *message) {
+        std::cerr << "channel error: " << message << std::endl;
+    });
+
     // create a temporary queue
-    channel.declareQueue(AMQP::exclusive).onSuccess([&connection](const std::string &name, uint32_t messagecount, uint32_t consumercount) {
-        
+    channel.declareQueue(AMQP::exclusive
+     ).onSuccess([](const std::string &name, uint32_t /* messagecount */, uint32_t /* consumercount */) {
+
         // report the name of the temporary queue
         std::cout << "declared queue " << name << std::endl;
-        
-        // now we can close the connection
-        connection.close();
-    });
-    
-    // run the handler
-    // a t the moment, one will need SIGINT to stop.  In time, should add signal handling through boost API.
-    return service.run();
-}
 
+    }).onError([](const char *message) {
+
+        // something went wrong creating the queue (or even before)
+        std::cerr << "declareQueue error: " << message << std::endl;
+    });
+
+    // run the handler
+    return context.run();
+}

--- a/examples/libboostasio.cpp
+++ b/examples/libboostasio.cpp
@@ -1,22 +1,337 @@
-/**
- *  LibBoostAsio.cpp
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
  *
- *  Test program to check AMQP functionality based on Boost's asio io_context.
+ * Copyright 2025 Copernica BV
  *
- *  @author Gavin Smith <gavin.smith@coralbay.tv>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Compile with:
- *  g++ -std=c++17 -Wall  libboostasio.cpp -o boost_test  -lboost_system -lamqpcpp -lpthread -ldl
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
+ *  libBoostAsio.cpp
+ *
+ *  Test program to check AMQP-CPP functionality with boost asio.
+ *
+ *  Compile with (append -lssl if #define USE_AMQPS):
+ *  g++ -std=c++17 -Wall -Wno-class-conversion libboostasio.cpp -o boost_test -lboost_system -lamqpcpp -lpthread -ldl
+ *
+ *  @author Paolo Pastori
  */
+
+/*
+ * uncomment (and link with -lssl) to use amqps instead of plain amqp
+ */
+#define USE_AMQPS
 
 /**
  *  Dependencies
  */
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/io_context.hpp>
+#ifdef USE_AMQPS
+#include <openssl/ssl.h>
+#include <openssl/opensslv.h>
+#endif // USE_AMQPS
+#include <chrono>
+#include <iomanip>
 
 #include <amqpcpp.h>
 #include <amqpcpp/libboostasio.h>
+
+
+using boost_errc = boost::system::error_code;
+
+/**
+ *  Class that runs a timer
+ */
+class MyTimer
+{
+private:
+    /**
+     *  The actual timer
+     *  @var boost::asio::steady_timer
+     */
+    boost::asio::steady_timer _timer;
+
+    /**
+     *  The counter for published messages
+     *  @var uint16_t
+     */
+    uint16_t _pno = 0;
+
+protected:
+    /**
+     *  Callback method that is called by boost when the timer expires
+     *  @param  ec  boost errorcode
+     */
+    void callback(const boost_errc& ec)
+    {
+        if (!ec && pchannel)
+        {
+            // publish a message
+            pchannel->publish("", queue, "Hello World");
+
+            std::cout << "message " << ++_pno << " published" << std::endl;
+
+            // reschedule
+            start();
+        }
+    }
+
+public:
+    /**
+     *  Period of the timer (ms)
+     *  @var uint16_t
+     */
+    uint16_t milli_seconds = 1000;
+
+    /**
+     *  Pointer towards the AMQP channel
+     *  @var AMQP::TcpChannel
+     */
+    AMQP::TcpChannel *pchannel;
+
+    /**
+     *  Name of the queue
+     *  @var std::string
+     */
+    std::string queue;
+
+    /**
+     *  Constructor
+     *  @param  ctx       The execution context
+     *  @param  pchannel  The TCP channel
+     */
+    MyTimer(boost::asio::io_context &ctx, AMQP::TcpChannel *pchannel = nullptr) :
+        _timer(ctx), pchannel(pchannel)
+    {
+    }
+
+    /**
+     *  Schedule the timer
+     */
+    void start()
+    {
+        if (milli_seconds)
+        {
+            _timer.expires_after(std::chrono::milliseconds(milli_seconds));
+            _timer.async_wait([this](const boost_errc& ec) { callback(ec); });
+        }
+    }
+
+    /**
+     *  Stop the timer
+     */
+    void stop()
+    {
+        _timer.cancel();
+    }
+
+    /**
+     *  Destructor
+     */
+    ~MyTimer()
+    {
+        stop();
+    }
+};
+
+
+/**
+ *  Custom handler
+ */
+class MyHandler : public AMQP::LibBoostAsioHandler
+{
+private:
+    /**
+     *  The set of signals to be used for process termination.
+     *  @var boost::asio::signal_set
+     */
+    boost::asio::signal_set _signals;
+
+    /**
+     *  The timer for periodical publishing
+     *  @var MyTimer*
+     */
+    MyTimer *_mytimer = nullptr;
+
+    /**
+     *  Method that is called when a connection error occurs
+     *  @param  connection  The TCP connection
+     *  @param  message     The error message
+     */
+    void onError(AMQP::TcpConnection* /* connection */, const char *message) override
+    {
+        std::cout << "error: " << std::quoted(message) << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection ends up in a connected state
+     *  @param  connection  The TCP connection
+     */
+    void onConnected(AMQP::TcpConnection *connection) override
+    {
+        std::cout << "connected\n";
+
+        // install the signals handler
+        _signals.async_wait([this, connection](const boost_errc& ec, int /* signal_number */) {
+            if (!ec) {
+                // now we gently close the connection
+                std::cerr << "\nclosing connection...\n";
+
+                // NOTE: there must be no callabacks queued in execution
+                //       context otherwise the process will hang
+                if (_mytimer) _mytimer->stop();
+
+                connection->close();
+            }
+        });
+        std::cout << "\n  Hit CTRL-C to exit\n" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection ends up in a ready
+     *  @param  connection  The TCP connection
+     */
+    void onReady(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "ready" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is closed
+     *  @param  connection  The TCP connection
+     */
+    void onClosed(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "closed" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection was blocked
+     *  @param  connection      The connection that was blocked
+     *  @param  reason          Why was the connection blocked
+     */
+    void onBlocked(AMQP::TcpConnection *connection, const char *reason) override
+    {
+        std::cout << "blocked with reason " << std::quoted(reason) << std::endl;
+
+        // avoid further publishing since we are blocked
+        if (_mytimer) _mytimer->stop();
+
+        // NOTE: doing a connection->close() has no effect here as
+        //       the server has already end to listen to us,
+        //       in this case if you want to leave without incur in
+        //       a deadlock must call the release mehod of the handler
+        // NOTE: there must also be no callabacks queued in execution
+        //       context otherwise the process will hang (timers, signals...)
+
+        // always tell the handler as good practice
+        return LibBoostAsioHandler::onBlocked(connection, reason);
+    }
+
+    /**
+     *  Method that is called when the TCP connection is no longer blocked
+     *  @param  connection      The connection that is no longer blocked
+     */
+    void onUnblocked(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "unblocked" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is lost or closed
+     *  @param  connection  The TCP connection
+     */
+    void onLost(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "lost" << std::endl;
+    }
+
+    /**
+     *  Method that is called when the TCP connection is detached
+     *  @param  connection  The TCP connection
+     */
+    void onDetached(AMQP::TcpConnection* /* connection */) override
+    {
+        std::cout << "detached" << std::endl;
+    }
+
+protected:
+    /**
+     *  Method that is called when the heartbeat frequency is negotiated
+     *
+     *  @param  connection  The TCP connection
+     *  @param  interval    The suggested interval from the server
+     *  @return uint16_t    The interval to use
+     */
+    uint16_t onNegotiate(AMQP::TcpConnection *connection, uint16_t interval) override
+    {
+        // could override server proposed interval here, i.e.
+        // uncoment to force interval 0 to suppress heartbeat
+        //interval = 0;
+
+        // must tell the handler
+        return LibBoostAsioHandler::onNegotiate(connection, interval);
+    }
+
+public:
+    /**
+     *  Constructor
+     *  @param  ctx  The execution context
+     */
+    MyHandler(boost::asio::io_context &ctx)
+        : AMQP::LibBoostAsioHandler(ctx), _signals(ctx, SIGINT, SIGTERM)
+    {
+    }
+
+    /**
+     *  Install the user timer
+     */
+    void set_timer(MyTimer *timer)
+    {
+        _mytimer = timer;
+    }
+
+    /**
+     *  Stop listening for signals
+     */
+    void stop_signals()
+    {
+        _signals.cancel();
+    }
+
+    /**
+     *  Destructor
+     */
+    virtual ~MyHandler() = default;
+};
+
+
+/**
+ *  Access to execution context
+ */
+boost::asio::io_context &get_context()
+{
+    static boost::asio::io_context ctx;
+
+    return ctx;
+}
 
 /**
  *  Main program
@@ -24,51 +339,105 @@
  */
 int main()
 {
-    // access to the boost asio handler
-    boost::asio::io_context context;
-
-    // set of signal for process termination (CTRL-C, kill)
-    boost::asio::signal_set signals(context, SIGINT, SIGTERM);
-
     // handler for libboostasio
-    AMQP::LibBoostAsioHandler handler(context);
+    MyHandler handler(get_context());
+
+#ifdef USE_AMQPS
+    // init the SSL library
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_library_init();
+#else
+    OPENSSL_init_ssl(0, NULL);
+#endif
+
+    AMQP::Address address("amqps://guest:guest@localhost/");
+#else
+    AMQP::Address address("amqp://guest:guest@localhost/");
+#endif // USE_AMQPS
 
     // make a connection
-    AMQP::TcpConnection connection(&handler, AMQP::Address("amqp://guest:guest@localhost/"));
+    AMQP::TcpConnection connection(&handler, address);
 
-    // we need a channel too
+    // make a channel
     AMQP::TcpChannel channel(&connection);
 
-    channel.onReady([&signals, &connection]() {
-        std::cout << "hit CTRL-C to exit\n\nchannel ready\n";
-
-        // install the signals handler
-        signals.async_wait([&connection](const boost::system::error_code& ec, int /* signal_number */)
-        {
-            if (!ec) {
-                // now we gently close the connection
-                std::cerr << "\nclosing connection...\n";
-                connection.close();
-            }
-        });
-    });
-    channel.onError([](const char *message) {
-        std::cerr << "channel error: " << message << std::endl;
-    });
+    // construct a timer that is going to publish stuff
+    MyTimer timer(get_context(), &channel);
+    // and install it on the handler
+    handler.set_timer(&timer);
 
     // create a temporary queue
-    channel.declareQueue(AMQP::exclusive
-     ).onSuccess([](const std::string &name, uint32_t /* messagecount */, uint32_t /* consumercount */) {
+    channel.declareQueue(AMQP::exclusive)
+      .onSuccess([&connection, &channel, &timer, &handler](const std::string &queuename, uint32_t messagecount, uint32_t consumercount) {
 
-        // report the name of the temporary queue
-        std::cout << "declared queue " << name << std::endl;
+        std::cout << "declared queue " << quoted(queuename) << std::endl;
 
-    }).onError([](const char *message) {
+        timer.queue = queuename;
 
-        // something went wrong creating the queue (or even before)
-        std::cerr << "declareQueue error: " << message << std::endl;
+/*        // close the channel
+        channel.close().onSuccess([&connection, &channel, &handler]() {
+
+            std::cout << "channel closed" << std::endl;
+
+            // close the connection
+            connection.close();
+
+            // NOTE: there must be no callabacks queued in execution
+            //       context otherwise the process will hang
+            handler.stop_signals();
+
+        }); */
+
+        // start a consumer
+        channel.consume(queuename).onReceived([&channel, queuename](const AMQP::Message &message, uint64_t deliveryTag, bool redelivered) {
+
+            std::cout << "received " << deliveryTag << std::endl;
+
+/*            // we remove the queue, to see if this indeed triggers the onCancelled method
+            if (deliveryTag > 4) channel.removeQueue(queuename); */
+
+            // ack the message
+            channel.ack(deliveryTag);
+
+        }).onSuccess([&timer](const std::string &tag) {
+
+            // the consumer is ready
+            std::cout << "started consuming with tag " << quoted(tag) << std::endl;
+
+            // start the publisher too
+            timer.start();
+
+        }).onCancelled([&timer](const std::string &tag) {
+
+            // the consumer was cancelled by the server
+            std::cout << "consumer " << quoted(tag) << " was cancelled" << std::endl;
+
+            // stop the publisher
+            timer.stop();
+
+        }).onError([&timer, &connection, &handler](const char *message) {
+
+            // the consumer was cancelled by the server
+            std::cout << "consumer operation failed" << std::endl;
+
+            // stop the publisher
+            timer.stop();
+
+            // close the connection
+            connection.close();
+
+            // NOTE: there must be no callabacks queued in execution
+            //       context otherwise the process will hang
+            handler.stop_signals();
+
+        });
+
+/*        // close the connection
+        connection.close();
+        // NOTE: this will have no effect, as the timer is not started yet
+        timer.stop(); */
     });
 
     // run the handler
-    return context.run();
+    return get_context().run();
 }

--- a/include/amqpcpp/deferred.h
+++ b/include/amqpcpp/deferred.h
@@ -178,7 +178,7 @@ protected:
         // store pointer
         _next = deferred;
     }
-    
+
     /**
      *  Remove this object from the chain of deferreds
      */
@@ -281,9 +281,6 @@ public:
      *  if and when the operation completes
      *  or fails. This function will be called
      *  either way.
-     *
-     *  In the case of success, the provided
-     *  error parameter will be an empty string.
      *
      *  Only one callback can be registered at at time.
      *  Successive calls to this function will clear

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -23,10 +23,11 @@
  *  Dependencies
  */
 #include <memory>
+#include <chrono>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/bind/bind.hpp>
@@ -83,10 +84,10 @@ protected:
         boost::asio::posix::stream_descriptor _socket;
 
         /**
-         *  The boost asynchronous deadline timer.
-         *  @var class boost::asio::deadline_timer
+         *  The boost asynchronous timer.
+         *  @var boost::asio::steady_timer
          */
-        boost::asio::deadline_timer _timer;
+        boost::asio::steady_timer _timer;
 
         /**
          *  A boolean that indicates if the watcher is monitoring for read events.
@@ -295,8 +296,8 @@ protected:
                     connection->heartbeat();
                 }
 
-                // Reschedule the timer for the future:
-                _timer.expires_at(_timer.expires_at() + boost::posix_time::seconds(timeout));
+                // reschedule the timer
+                _timer.expires_after(std::chrono::seconds(timeout));
 
                 // Posts the timer event
                 _timer.async_wait(get_timer_handler(connection, timeout));
@@ -387,11 +388,14 @@ protected:
             // stop timer in case it was already set
             stop_timer();
 
-            // Reschedule the timer for the future:
-            _timer.expires_from_now(boost::posix_time::seconds(timeout));
+            if (timeout)
+            {
+                // schedule the timer
+                _timer.expires_after(std::chrono::seconds(timeout));
 
-            // Posts the timer event
-            _timer.async_wait(get_timer_handler(connection, timeout));
+                // Posts the timer event
+                _timer.async_wait(get_timer_handler(connection, timeout));
+            }
         }
 
         /**
@@ -503,9 +507,7 @@ public:
     explicit LibBoostAsioHandler(boost::asio::io_context &io_context) :
         _iocontext(io_context),
         _strand(std::make_shared<boost::asio::io_context::strand>(_iocontext))
-        //_timer(std::make_shared<Timer>(_iocontext,_strand))
     {
-
     }
 
     /**

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -114,28 +114,22 @@ protected:
         steady_time_point _expire;
 
         /**
+         *  The events for which the socket filedescriptor is actually monitored.
+         *  @var int
+         */
+        int _events = 0;
+
+        /**
          *  A boolean that indicates if the watcher is monitoring for read events.
          *  @var _read True if reads are being monitored else false.
          */
         bool _read = false;
 
         /**
-         *  A boolean that indicates if the watcher has a pending read event.
-         *  @var _read_pending True if read is pending else false.
-         */
-        bool _read_pending = false;
-
-        /**
          *  A boolean that indicates if the watcher is monitoring for write events.
          *  @var _write True if writes are being monitored else false.
          */
         bool _write = false;
-
-        /**
-         *  A boolean that indicates if the watcher has a pending write event.
-         *  @var _write_pending True if read is pending else false.
-         */
-        bool _write_pending = false;
 
         using handler_cb = std::function<void(boost::system::error_code)>;
 
@@ -192,8 +186,6 @@ protected:
                           TcpConnection *const connection,
                           const int fd)
         {
-            _read_pending = false;
-
             if (!ec && _read)
             {
                 if (_timeout)
@@ -208,9 +200,7 @@ protected:
                 // still we need monitoring read?
                 if (_socket.is_open())
                 {
-                    _read_pending = true;  // This is a problem waiting to manifest,
-                       /////////////          what if suspended here while more events
-                    _socket.async_wait(    // occurs?  See bottom NOTE
+                    _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_read,
                         get_read_handler(connection, fd));
                 }
@@ -235,8 +225,6 @@ protected:
                            TcpConnection *const connection,
                            const int fd)
         {
-            _write_pending = false;
-
             if (!ec && _write)
             {
                 if (_timeout)
@@ -251,9 +239,7 @@ protected:
                 // still we need monitoring write?
                 if (_socket.is_open())
                 {
-                    _write_pending = true;  // This is a problem waiting to manifest,
-                       /////////////           what if suspended here while more events
-                    _socket.async_wait(     // occurs?  See bottom NOTE
+                    _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_write,
                         get_write_handler(connection, fd));
                 }
@@ -376,34 +362,39 @@ protected:
 
         /**
          *  Change the events for which the filedescriptor is monitored
-         *  @param  events
+         *  @param  connection  The connection being watched.
+         *  @param  fd          The file descripter being watched.
+         *  @param  events      The events to monitor (readable, writable or both)
          */
-        void events(TcpConnection *connection, int fd, int events)
+        void events(TcpConnection *const connection, int fd, int events)
         {
-            // 1. Handle reads?
-            _read = ((events & AMQP::readable) != 0);
-
-            // Read requsted but no read pending?
-            if (_read && !_read_pending)
+            if (events != _events)
             {
-                _read_pending = true;  // This is a problem waiting to manifest,
-                   /////////////          what if suspended here while more events
-                _socket.async_wait(    // occurs?  See bottom NOTE
-                    boost::asio::posix::stream_descriptor::wait_read,
-                    get_read_handler(connection, fd));
-            }
+                // cancel pending io callback
+                _socket.cancel();
 
-            // 2. Handle writes?
-            _write = ((events & AMQP::writable) != 0);
+                // handle reads?
+                _read = ((events & AMQP::readable) != 0);
 
-            // Write requested but no write pending?
-            if (_write && !_write_pending)
-            {
-                _write_pending = true;  // This is a problem waiting to manifest,
-                   /////////////           what if suspended here while more events
-                _socket.async_wait(     // occurs?  See bottom NOTE
-                    boost::asio::posix::stream_descriptor::wait_write,
-                    get_write_handler(connection, fd));
+                if (_read)
+                {
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_read,
+                        get_read_handler(connection, fd));
+                }
+
+                // handle writes?
+                _write = ((events & AMQP::writable) != 0);
+
+                if (_write)
+                {
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_write,
+                        get_write_handler(connection, fd));
+                }
+
+                // remember current events
+                _events = events;
             }
         }
 
@@ -510,8 +501,8 @@ protected:
         // was it found?
         if (iter == _watchers.end())
         {
-            // we did not yet have this watcher - but that is ok if no filedescriptor was registered
-            if (flags == 0){ return; }
+            // a new watcher is required
+            if (flags == 0){ return; } // FIXME: a watcher should not be dead on arrival
 
             // construct a new watcher
             const std::shared_ptr<Watcher> spwatcher =
@@ -537,7 +528,7 @@ protected:
         }
         else
         {
-            // Change the events on which to act.
+            // reconfigure the events to monitor
             iter->second->events(connection, fd, flags);
         }
     }
@@ -558,7 +549,7 @@ protected:
         const int fd = connection->fileno();
 
         auto iter = _watchers.find(fd);
-        if (iter == _watchers.end()) return 0;
+        if (iter == _watchers.end()) return 0; // FIXME: a watcher must exist when negotiating the heartbeat
 
         // apply heartbeat monitor
         iter->second->set_heartbeat(timeout);
@@ -617,13 +608,18 @@ public:
 }
 /*
  * NOTE
- * Regarding the limitations of this handler.
+ * Regarding the peculiarities of this handler.
+ *
+ * To avoid confusion here I use the term callback to refer to the completion
+ * handler of boost asio, while I speak of handler with reference to the
+ * LibBoostAsioHandler.
  *
  * This handler is inspired by the others that preceded it (i.e. LibEvHandler,
  * LibEventHandler, LibUvHandler), but the strategy used to monitor the socket
  * filedescriptor is completely different.  While other handlers rely on calls
  * like select/poll or similar to be woken up when a filedescriptor becomes
- * readable/writable, this one uses boost's async_wait.
+ * readable/writable, this one uses boost asio's async_wait.
+ *
  * Since callbacks queued in the execution context are not automatically
  * requeued once executed, additional work is required to continue monitoring
  * the socket's readability/writableness.  This is not necessary with the other
@@ -631,16 +627,28 @@ public:
  * checks multiple conditions *simultaneously*, whereas here we are also forced
  * to manage readable and writeable conditions separately.
  *
- * This brings us to the need to use a state machine, which is implemented here
- * using the boolean flags _read, _read_pending, _write, _write_pending.
- * As you can see the _pending flags are used to reschedule callbacks, so if
- * for some reason the thread is suspended after setting the flag but before
- * rescheduling the callback this can result in missed reads/writes.
+ * It is therefore essential that when the library requires monitoring a file
+ * descriptor being read, there is always a handler queued in the execution
+ * context (or executing) that takes care of it.  This condition is signaled by
+ * the _read flag of the Watcher which takes care of the relative
+ * filedescriptor.  The same goes for writing.
  *
- * Even though all library callbacks are executed in order on the same strand,
- * this is YET ANOTHER reason to stick to a single-threaded execution model.
+ * Probably even more importantly, this callback must not only be there but
+ * also be UNIQUE.  In the past, this handler had many problems related to the
+ * simultaneous existence of multiple callbacks monitoring the same condition
+ * on the same filedescriptor.  Typically this happened with TLS connections.
  *
- * Anyway I have already fixed this race condition in a future version of the
- * handler that will do without such flags.
+ * However, there are also cases where a single callback causes problems,
+ * because it simply shouldn't exist.  To understand these cases, consider that
+ * the boost reactor doesn't terminate execution if there are queued callbacks.
+ * In short, io_context::run() doesn't return unless we clear all callbacks.
+ * Under these conditions, a program refuses to terminate and hangs.
+ *
+ * So it's important to make sure we clear out all callbacks as soon as
+ * they're no longer needed.
+ *
+ * Ensuring that there aren't too many callbacks is definitely the handler's
+ * responsibility.  But deleting them all at the end may in some cases require
+ * the cooperation of the handler's user.
  *                                                             Paolo
  */

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -79,13 +79,11 @@ protected:
     {
     private:
 
-        using strand_weak_ptr = std::weak_ptr<boost::asio::io_context::strand>;
-
         /**
-         *  The boost asio io_context::strand managed pointer.
-         *  @var std::weak_ptr<boost::asio::io_context::strand>
+         *  The parent Handler.
+         *  @var LibBoostAsioHandler
          */
-        strand_weak_ptr _wpstrand;
+        LibBoostAsioHandler *_parent;
 
         /**
          *  The boost tcp socket.
@@ -167,26 +165,21 @@ protected:
 #else
             std::weak_ptr<Watcher> wpthis(shared_from_this());
 #endif
-            const strand_weak_ptr wpstrand = _wpstrand;
 
             return
 #if __cplusplus >= 201402L
                 // C++14 lambda has init capture
-                [wpthis=std::move(wpthis), wpstrand=std::move(wpstrand), mmfn=std::forward<M>(mmfn),
+                [wpthis=std::move(wpthis), mmfn=std::forward<M>(mmfn),
                                          connection, fd] (const boost::system::error_code& ec)
 #else
-                [wpthis, wpstrand, mmfn, connection, fd] (const boost::system::error_code& ec)
+                [wpthis, mmfn, connection, fd] (const boost::system::error_code& ec)
 #endif
                 {
                     const std::shared_ptr<Watcher> spwatcher = wpthis.lock();
                     // is the watcher still here?
                     if (!spwatcher) return;
 
-                    const strand_shared_ptr strand = wpstrand.lock();
-                    // is the strand still here?
-                    if (!strand) return;
-
-                    boost::asio::dispatch(*strand,
+                    boost::asio::dispatch(spwatcher->_parent->_strand,
                         // moving spwatcher into the bind ensures that the watcher
                         // will not be destroyed for the duration of the callback
                         std::bind(std::move(mmfn), std::move(spwatcher), ec, connection, fd));
@@ -343,10 +336,10 @@ protected:
          *  @param  connection_timeout   The AMQP server connection timeout
          */
         Watcher(boost::asio::io_context &io_context,
-                const strand_weak_ptr wpstrand,
+                LibBoostAsioHandler *parent,
                 const int fd,
                 uint16_t connection_timeout) :
-            _wpstrand(wpstrand),
+            _parent(parent),
             _socket(io_context),
             _timer(io_context),
             _connection_timeout(connection_timeout)
@@ -482,13 +475,11 @@ protected:
      */
     boost::asio::io_context & _iocontext;
 
-    using strand_shared_ptr = std::shared_ptr<boost::asio::io_context::strand>;
-
     /**
      *  The boost asio io_context::strand managed pointer.
-     *  @var std::shared_ptr<boost::asio::io_context::strand>
+     *  @var boost::asio::io_context::strand
      */
-    strand_shared_ptr _strand;
+    boost::asio::io_context::strand _strand;
 
     /**
      *  Active I/O watchers, indexed by their filedescriptor.
@@ -525,7 +516,7 @@ protected:
 
             // construct a new watcher, and register as active
             _watchers[fd] =
-                std::make_shared<Watcher>(_iocontext, _strand, fd, _connection_timeout);
+                std::make_shared<Watcher>(_iocontext, this, fd, _connection_timeout);
 
             auto &spwatcher = _watchers[fd];
 
@@ -627,7 +618,7 @@ public:
     explicit LibBoostAsioHandler(boost::asio::io_context &io_context,
                                  uint16_t connection_timeout = 60) :
         _iocontext(io_context),
-        _strand(std::make_shared<boost::asio::io_context::strand>(_iocontext)),
+        _strand(io_context),
         _connection_timeout(connection_timeout)
     {
     }

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <chrono>
 #include <functional>
+#include <cassert>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
@@ -502,7 +503,7 @@ protected:
         if (iter == _watchers.end())
         {
             // a new watcher is required
-            if (flags == 0){ return; } // FIXME: a watcher should not be dead on arrival
+            assert(flags != 0); // a watcher should not be dead on arrival
 
             // construct a new watcher
             const std::shared_ptr<Watcher> spwatcher =
@@ -549,7 +550,7 @@ protected:
         const int fd = connection->fileno();
 
         auto iter = _watchers.find(fd);
-        if (iter == _watchers.end()) return 0; // FIXME: a watcher must exist when negotiating the heartbeat
+        assert(iter != _watchers.end()); // a watcher must exist when negotiating the heartbeat
 
         // apply heartbeat monitor
         iter->second->set_heartbeat(timeout);

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -12,6 +12,7 @@
  *
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
+ *  @author Paolo Pastori
  */
 
 /**
@@ -265,7 +266,7 @@ protected:
     public:
 
         /**
-         *  Constructor- initialises the watcher and assigns the filedescriptor to
+         *  Constructor - initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
          *  @param  io_context      The boost io_context
          *  @param  wpstrand        A weak pointer to a io_context::strand instance.
@@ -293,17 +294,17 @@ protected:
         Watcher(const Watcher &that) = delete;
 
         /**
-         *  Destructor
+         *  Destructors
          */
-        ~Watcher()
+        void close()
         {
-            _read = false;
-            _write = false;
             // release ownership of filedescriptor and cancel pending io callbacks
             _socket.release();
             // cancel any pending timer callback
             stop_timer();
         }
+
+        ~Watcher() { close(); }
 
         /**
          *  Change the events for which the filedescriptor is monitored
@@ -416,19 +417,24 @@ protected:
             // we did not yet have this watcher - but that is ok if no filedescriptor was registered
             if (flags == 0){ return; }
 
-            // construct a new pair (watcher/timer), and put it in the map
-            const std::shared_ptr<Watcher> apWatcher =
+            // construct a new watcher
+            const std::shared_ptr<Watcher> spwatcher =
                 std::make_shared<Watcher>(_iocontext, _strand, fd);
 
-            _watchers[fd] = apWatcher;
+            // register as active
+            _watchers[fd] = spwatcher;
 
             // explicitly set the events to monitor
-            apWatcher->events(connection, fd, flags);
+            spwatcher->events(connection, fd, flags);
         }
         else if (flags == 0)
         {
-            // the watcher does already exist, but we no longer have to watch this watcher
+            // the watcher does not need anymore, unregister
             _watchers.erase(iter);
+
+            // have to release the filedescriptor immediately, cannot rely on the
+            // dtor for that since must wait for all the callback to terminate
+            iter->second->close();
         }
         else
         {

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -56,12 +56,6 @@ protected:
     {
     private:
 
-        /**
-         *  The boost asio io_context which is responsible for detecting events.
-         *  @var boost::asio::io_context&
-         */
-        boost::asio::io_context & _iocontext;
-
         using strand_weak_ptr = std::weak_ptr<boost::asio::io_context::strand>;
 
         /**
@@ -329,7 +323,6 @@ protected:
                 const strand_weak_ptr wpstrand,
                 const int fd,
                 uint16_t connection_timeout) :
-            _iocontext(io_context),
             _wpstrand(wpstrand),
             _socket(io_context),
             _timer(io_context),

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -1,4 +1,27 @@
-/**
+/*
+ * This software is the product of voluntary contributions, which Copernica BV
+ * distributes alongside with the proprietary code for the sole purpose of
+ * allowing its circulation, and is subject to the same license terms:
+ *
+ * Copyright 2025 Copernica BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Specifically, regarding the code contained in this file, Copernica BV
+ * IS NOT INVOLVED IN ANY ACTIVITY BEYOND DISTRIBUTION. IT DOES NOT PROVIDE
+ * TECHNICAL SUPPORT, MAINTENANCE, OR ANY OTHER SERVICES.
+ *
+ *
  *  LibBoostAsio.h
  *
  *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class
@@ -6,9 +29,8 @@
  *  constructor and you're all set.  See examples/libboostasio.cpp for an example.
  *
  *  Watch out: this class was not implemented or reviewed by the original author of
- *  AMQP-CPP. However, we do get a lot of questions and issues from users of this class,
- *  so we cannot guarantee its quality. If you run into such issues too, it might be
- *  better to implement your own handler that interact with boost.
+ *  AMQP-CPP. If you run into some issues, it might be better to implement your own
+ *  handler that interact with boost.
  *
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
@@ -601,8 +623,8 @@ public:
  */
 }
 /*
- * NOTE
- * Regarding the peculiarities of this handler.
+ * [1] Regarding the peculiarities of this handler.
+ *     ============================================
  *
  * To avoid confusion here I use the term callback to refer to the completion
  * handler of boost asio, while I speak of handler with reference to the
@@ -622,7 +644,7 @@ public:
  * to manage readable and writeable conditions separately.
  *
  * It is therefore essential that when the library requires monitoring a file
- * descriptor being read, there is always a handler queued in the execution
+ * descriptor being read, there is always a callback queued in the execution
  * context (or executing) that takes care of it.  This condition is signaled by
  * the _read flag of the Watcher which takes care of the relative
  * filedescriptor.  The same goes for writing.
@@ -644,5 +666,27 @@ public:
  * Ensuring that there aren't too many callbacks is definitely the handler's
  * responsibility.  But deleting them all at the end may in some cases require
  * the cooperation of the handler's user.
+ *
+ *
+ * [2] About LibBoostAsio and thread safety.
+ *     =====================================
+ *
+ * AMQP-CPP is not thread safe, we cannot repeat this too many times.
+ *
+ * But I think we should definitely give credit to Gavin Smith, the original
+ * author of this handler, for the intuition that with the help of the boost
+ * reactor it could get pretty close.  The reactor ensures that queued
+ * callbacks are executed exclusively by threads that are running the context
+ * (io_context::run()) and the io_context::strand ensures that each callback
+ * is executed sequentially and every other thread in the pool sees its effects.
+ *
+ * So boost magically makes AMQP-CPP thread safe?
+ *
+ * IF ALL THE THREADS INVOLVED ARE RUNNING THE CONTEXT THEN ALL THE CALLS TO
+ * AMQP-CPP ORIGINATE FROM CALLBACKS AND THEREFORE THERE ARE NO PROBLEMS
+ *                                   BUT
+ * IF A THREAD INTERACTS WITH THE LIBRARY WITHOUT GOING THROUGH THE REACTOR
+ * (for example it directly invoke publish) THEN EXPECT AN INDETERMINATE
+ * BEHAVIOR.
  *                                                             Paolo
  */

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -178,22 +178,19 @@ protected:
                     // here, we are guaranteed by design that the "this"
                     // will not dangle without our intervention
                     boost::asio::dispatch(this->_parent->_strand,
-                        std::bind(std::move(mmfn), this, ec, connection, fd));
+                        std::bind(std::move(mmfn), this, connection, fd));
                 };
         }
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a read event.
-         *  @param  ec          The status of the callback.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
-         *  @note   The handler will get called if a read is cancelled.
          */
-        void read_handler(const boost_errc &ec,
-                          TcpConnection *const connection,
+        void read_handler(TcpConnection *const connection,
                           const int fd)
         {
-            if (!ec && _read)
+            if (_read)
             {
                 if (_timeout)
                 {
@@ -224,16 +221,13 @@ protected:
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a write event.
-         *  @param  ec          The status of the callback.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
-         *  @note   The handler will get called if a write is cancelled.
          */
-        void write_handler(const boost_errc ec,
-                           TcpConnection *const connection,
+        void write_handler(TcpConnection *const connection,
                            const int fd)
         {
-            if (!ec && _write)
+            if (_write)
             {
                 if (_timeout)
                 {
@@ -264,16 +258,13 @@ protected:
 
         /**
          *  Handler method that is called by boost's io_context when the timer expires.
-         *  @param  ec          The status of the callback.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
-         *  @note   The handler will get called if a timer is cancelled.
          */
-        void timer_handler(const boost_errc &ec,
-                           TcpConnection *const connection,
+        void timer_handler(TcpConnection *const connection,
                            const int fd)
         {
-            if (!ec && _socket.is_open())
+            if (_socket.is_open())
             {
                 steady_time_point now = std::chrono::steady_clock::now();
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -48,6 +48,7 @@
 #include <memory>
 #include <chrono>
 #include <functional>
+#include <algorithm>
 #include <cassert>
 
 #include <boost/asio/io_context.hpp>
@@ -518,7 +519,9 @@ protected:
         if (iter == _watchers.end())
         {
             // a new watcher is required
-            assert(flags != 0); // a watcher should not be dead on arrival
+
+            // should have some flags, unless there was an early release
+            if (flags == 0) return;
 
             // construct a new watcher
             const std::shared_ptr<Watcher> spwatcher =
@@ -575,6 +578,41 @@ protected:
         return timeout;
     }
 
+    /**
+     *  Stop handling connection(s).
+     *
+     *  Note that you cannot continue using the connection(s) after calling
+     *  this method.
+     *  @param  connection  The TcpConnection to release (all by default).
+     *  @return bool        If there was a release.
+     */
+    bool release(const TcpConnection *connection = nullptr)
+    {
+        if (connection == nullptr)
+        {
+            // close all watchers
+            for (auto &wp : _watchers) wp.second->close();
+            auto b = _watchers.begin();
+            return b != _watchers.erase(b, _watchers.end());
+        }
+        else
+        {
+            int fd = connection->fileno();
+            // is the connection already closed?
+            if (fd != -1) {
+                // close matching watcher
+                auto iter = _watchers.find(fd);
+                if (iter != _watchers.end())
+                {
+                    iter->second->close();
+                    _watchers.erase(iter);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
 public:
 
     /**
@@ -615,7 +653,10 @@ public:
     /**
      *  Destructor
      */
-    ~LibBoostAsioHandler() override = default;
+    ~LibBoostAsioHandler() override
+    {
+        release();
+    }
 };
 
 /**
@@ -665,7 +706,8 @@ public:
  *
  * Ensuring that there aren't too many callbacks is definitely the handler's
  * responsibility.  But deleting them all at the end may in some cases require
- * the cooperation of the handler's user.
+ * the cooperation of the handler's user, at this purpose see the handler's
+ * release method.
  *
  *
  * [2] About LibBoostAsio and thread safety.

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -239,6 +239,13 @@ protected:
 
             if (!ec && _write)
             {
+                if (_timeout)
+                {
+                    // the client is sending data, update the _next time
+                    _next = std::chrono::steady_clock::now() +
+                            std::chrono::seconds((_timeout >> 1) + 1);
+                }
+
                 connection->process(fd, AMQP::writable);
 
                 // still we need monitoring write?

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -75,7 +75,7 @@ protected:
     /**
      *  Helper class that wraps a boost io_context socket monitor.
      */
-    class Watcher : public std::enable_shared_from_this<Watcher>
+    class Watcher
     {
     private:
 
@@ -147,7 +147,8 @@ protected:
          */
         bool _write = false;
 
-        using handler_cb = std::function<void(boost::system::error_code)>;
+        using boost_errc = boost::system::error_code;
+        using handler_cb = std::function<void(boost_errc)>;
 
         /**
          *  Make a generic handler callback.
@@ -159,30 +160,25 @@ protected:
         template <typename M>
         handler_cb make_handler(M &&mmfn, TcpConnection *const connection, const int fd)
         {
-#if __cplusplus >= 201701L
-            // C++17 has weak_from_this()
-            std::weak_ptr<Watcher> wpthis = weak_from_this();
-#else
-            std::weak_ptr<Watcher> wpthis(shared_from_this());
-#endif
-
             return
 #if __cplusplus >= 201402L
                 // C++14 lambda has init capture
-                [wpthis=std::move(wpthis), mmfn=std::forward<M>(mmfn),
-                                         connection, fd] (const boost::system::error_code& ec)
+                [this, mmfn=std::forward<M>(mmfn), connection, fd] (const boost_errc& ec)
 #else
-                [wpthis, mmfn, connection, fd] (const boost::system::error_code& ec)
+                [this, mmfn, connection, fd] (const boost_errc& ec)
 #endif
                 {
-                    const std::shared_ptr<Watcher> spwatcher = wpthis.lock();
-                    // is the watcher still here?
-                    if (!spwatcher) return;
-
-                    boost::asio::dispatch(spwatcher->_parent->_strand,
-                        // moving spwatcher into the bind ensures that the watcher
-                        // will not be destroyed for the duration of the callback
-                        std::bind(std::move(mmfn), std::move(spwatcher), ec, connection, fd));
+                    if (ec) {
+                        // upon object destruction, all callbacks are invoked with
+                        // the error code boost::asio::error::operation_aborted,
+                        // but regardless of the error, you should exit immediately
+                        // because "this" is likely to be invalidated.
+                        return;
+                    }
+                    // here, we are guaranteed by design that the "this"
+                    // will not dangle without our intervention
+                    boost::asio::dispatch(this->_parent->_strand,
+                        std::bind(std::move(mmfn), this, ec, connection, fd));
                 };
         }
 
@@ -193,7 +189,7 @@ protected:
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a read is cancelled.
          */
-        void read_handler(const boost::system::error_code &ec,
+        void read_handler(const boost_errc &ec,
                           TcpConnection *const connection,
                           const int fd)
         {
@@ -207,6 +203,7 @@ protected:
                 }
 
                 connection->process(fd, AMQP::readable);
+                // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring read?
                 if (_socket.is_open())
@@ -232,7 +229,7 @@ protected:
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a write is cancelled.
          */
-        void write_handler(const boost::system::error_code ec,
+        void write_handler(const boost_errc ec,
                            TcpConnection *const connection,
                            const int fd)
         {
@@ -246,6 +243,7 @@ protected:
                 }
 
                 connection->process(fd, AMQP::writable);
+                // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring write?
                 if (_socket.is_open())
@@ -271,7 +269,7 @@ protected:
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a timer is cancelled.
          */
-        void timer_handler(const boost::system::error_code &ec,
+        void timer_handler(const boost_errc &ec,
                            TcpConnection *const connection,
                            const int fd)
         {
@@ -331,7 +329,7 @@ protected:
          *  Constructor - initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
          *  @param  io_context           The boost io_context
-         *  @param  wpstrand             A weak pointer to a io_context::strand instance.
+         *  @param  parent               The parent Handler
          *  @param  fd                   The filedescriptor being watched
          *  @param  connection_timeout   The AMQP server connection timeout
          */
@@ -485,7 +483,7 @@ protected:
      *  Active I/O watchers, indexed by their filedescriptor.
      *  @var std::map<int, Watcher>
      */
-    std::map<int, std::shared_ptr<Watcher> > _watchers;
+    std::map<int, std::unique_ptr<Watcher>> _watchers;
 
     /**
      *  AMQP Server connection timeout setting (seconds).
@@ -516,24 +514,25 @@ protected:
 
             // construct a new watcher, and register as active
             _watchers[fd] =
-                std::make_shared<Watcher>(_iocontext, this, fd, _connection_timeout);
+#if __cplusplus >= 201402L
+            // C++14 has make_unique(
+                std::make_unique<Watcher>(_iocontext, this, fd, _connection_timeout);
+#else
+                std::unique_ptr<Watcher>(new Watcher(_iocontext, this, fd, _connection_timeout));
+#endif
 
-            auto &spwatcher = _watchers[fd];
+            auto &upwatcher = _watchers[fd];
 
             // apply server connection timeout monitor
-            spwatcher->apply_connection_timeout(connection, fd);
+            upwatcher->apply_connection_timeout(connection, fd);
 
             // explicitly set the events to monitor
-            spwatcher->set_event_mask(connection, fd, flags);
+            upwatcher->set_event_mask(connection, fd, flags);
         }
         else if (flags == 0)
         {
             // the watcher does not need anymore, unregister
             _watchers.erase(iter);
-
-            // have to release the filedescriptor immediately, cannot rely on the
-            // dtor for that since must wait for all the callback to terminate
-            iter->second->close();
         }
         else
         {

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -2,8 +2,8 @@
  *  LibBoostAsio.h
  *
  *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class
- *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the
- *  constructor and you're all set.  See tests/libboostasio.cpp for example.
+ *  instead of a AMQP::TcpHandler class, just pass the boost asio io_context to the
+ *  constructor and you're all set.  See examples/libboostasio.cpp for an example.
  *
  *  Watch out: this class was not implemented or reviewed by the original author of
  *  AMQP-CPP. However, we do get a lot of questions and issues from users of this class,
@@ -50,14 +50,14 @@ namespace AMQP {
  *  Class definition
  *  @note Because of a limitation on Windows, this will only work on POSIX based systems - see https://github.com/chriskohlhoff/asio/issues/70
  */
-class LibBoostAsioHandler : public virtual TcpHandler
+class LibBoostAsioHandler : public TcpHandler
 {
 protected:
 
     /**
      *  Helper class that wraps a boost io_context socket monitor.
      */
-    class Watcher : public virtual std::enable_shared_from_this<Watcher>
+    class Watcher : public std::enable_shared_from_this<Watcher>
     {
     private:
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -80,10 +80,10 @@ protected:
     private:
 
         /**
-         *  The parent Handler.
-         *  @var LibBoostAsioHandler
+         *  The boost asio strand.
+         *  @var boost::asio::io_context::strand
          */
-        LibBoostAsioHandler *_parent;
+        boost::asio::io_context::strand &_strand;
 
         /**
          *  The boost tcp socket.
@@ -177,7 +177,7 @@ protected:
                     }
                     // here, we are guaranteed by design that the "this"
                     // will not dangle without our intervention
-                    boost::asio::dispatch(this->_parent->_strand,
+                    boost::asio::dispatch(this->_strand,
                         std::bind(std::move(mmfn), this, connection, fd));
                 };
         }
@@ -320,21 +320,19 @@ protected:
          *  Constructor - initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
          *  @param  io_context           The boost io_context
-         *  @param  parent               The parent Handler
+         *  @param  strand               The boost asio strand
          *  @param  fd                   The filedescriptor being watched
          *  @param  connection_timeout   The AMQP server connection timeout
          */
         Watcher(boost::asio::io_context &io_context,
-                LibBoostAsioHandler *parent,
+                boost::asio::io_context::strand &strand,
                 const int fd,
                 uint16_t connection_timeout) :
-            _parent(parent),
-            _socket(io_context),
+            _strand(strand),
+            _socket(io_context, fd),
             _timer(io_context),
             _connection_timeout(connection_timeout)
         {
-            _socket.assign(fd);
-
             _socket.non_blocking(true);
         }
 
@@ -507,9 +505,9 @@ protected:
             _watchers[fd] =
 #if __cplusplus >= 201402L
             // C++14 has make_unique(
-                std::make_unique<Watcher>(_iocontext, this, fd, _connection_timeout);
+                std::make_unique<Watcher>(_iocontext, _strand, fd, _connection_timeout);
 #else
-                std::unique_ptr<Watcher>(new Watcher(_iocontext, this, fd, _connection_timeout));
+                std::unique_ptr<Watcher>(new Watcher(_iocontext, _strand, fd, _connection_timeout));
 #endif
 
             auto &upwatcher = _watchers[fd];

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -203,7 +203,7 @@ protected:
                 // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring read?
-                if (_socket.is_open())
+                if (_read && _socket.is_open())
                 {
                     _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_read,
@@ -240,7 +240,7 @@ protected:
                 // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring write?
-                if (_socket.is_open())
+                if (_write && _socket.is_open())
                 {
                     _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_write,
@@ -470,7 +470,7 @@ protected:
 
     /**
      *  Active I/O watchers, indexed by their filedescriptor.
-     *  @var std::map<int, Watcher>
+     *  @var std::map<int, std::unique_ptr<Watcher>>
      */
     std::map<int, std::unique_ptr<Watcher>> _watchers;
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -378,12 +378,12 @@ protected:
         ~Watcher() { close(); }
 
         /**
-         *  Change the events for which the filedescriptor is monitored
+         *  Set the events for which the filedescriptor is monitored
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descripter being watched.
          *  @param  events      The events to monitor (readable, writable or both)
          */
-        void events(TcpConnection *const connection, int fd, int events)
+        void set_event_mask(TcpConnection *const connection, int fd, int events)
         {
             if (events != _events)
             {
@@ -523,18 +523,17 @@ protected:
             // should have some flags, unless there was an early release
             if (flags == 0) return;
 
-            // construct a new watcher
-            const std::shared_ptr<Watcher> spwatcher =
+            // construct a new watcher, and register as active
+            _watchers[fd] =
                 std::make_shared<Watcher>(_iocontext, _strand, fd, _connection_timeout);
 
-            // register as active
-            _watchers[fd] = spwatcher;
+            auto &spwatcher = _watchers[fd];
 
             // apply server connection timeout monitor
             spwatcher->apply_connection_timeout(connection, fd);
 
             // explicitly set the events to monitor
-            spwatcher->events(connection, fd, flags);
+            spwatcher->set_event_mask(connection, fd, flags);
         }
         else if (flags == 0)
         {
@@ -548,7 +547,7 @@ protected:
         else
         {
             // reconfigure the events to monitor
-            iter->second->events(connection, fd, flags);
+            iter->second->set_event_mask(connection, fd, flags);
         }
     }
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -64,7 +64,7 @@ protected:
 
         /**
          *  The boost asio io_context which is responsible for detecting events.
-         *  @var class boost::asio::io_context&
+         *  @var boost::asio::io_context&
          */
         boost::asio::io_context & _iocontext;
 
@@ -329,7 +329,9 @@ protected:
         {
             _read = false;
             _write = false;
+            // release ownership of filedescriptor and cancel pending io callbacks
             _socket.release();
+            // cancel any pending timer callback
             stop_timer();
         }
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -476,7 +476,7 @@ protected:
     boost::asio::io_context & _iocontext;
 
     /**
-     *  The boost asio io_context::strand managed pointer.
+     *  The boost asio strand.
      *  @var boost::asio::io_context::strand
      */
     boost::asio::io_context::strand _strand;

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -176,9 +176,9 @@ protected:
                 // still we need monitoring read?
                 if (_socket.is_open())
                 {
-                    _read_pending = true;
-
-                    _socket.async_wait(
+                    _read_pending = true;  // This is a problem waiting to manifest,
+                       /////////////          what if suspended here while more events
+                    _socket.async_wait(    // occurs?  See bottom NOTE
                         boost::asio::posix::stream_descriptor::wait_read,
                         get_read_handler(connection, fd));
                 }
@@ -212,9 +212,9 @@ protected:
                 // still we need monitoring write?
                 if (_socket.is_open())
                 {
-                    _write_pending = true;
-
-                    _socket.async_wait(
+                    _write_pending = true;  // This is a problem waiting to manifest,
+                       /////////////           what if suspended here while more events
+                    _socket.async_wait(     // occurs?  See bottom NOTE
                         boost::asio::posix::stream_descriptor::wait_write,
                         get_write_handler(connection, fd));
                 }
@@ -317,9 +317,9 @@ protected:
             // Read requsted but no read pending?
             if (_read && !_read_pending)
             {
-                _read_pending = true;
-
-                _socket.async_wait(
+                _read_pending = true;  // This is a problem waiting to manifest,
+                   /////////////          what if suspended here while more events
+                _socket.async_wait(    // occurs?  See bottom NOTE
                     boost::asio::posix::stream_descriptor::wait_read,
                     get_read_handler(connection, fd));
             }
@@ -330,9 +330,9 @@ protected:
             // Write requested but no write pending?
             if (_write && !_write_pending)
             {
-                _write_pending = true;
-
-                _socket.async_wait(
+                _write_pending = true;  // This is a problem waiting to manifest,
+                   /////////////           what if suspended here while more events
+                _socket.async_wait(     // occurs?  See bottom NOTE
                     boost::asio::posix::stream_descriptor::wait_write,
                     get_write_handler(connection, fd));
             }
@@ -507,3 +507,32 @@ public:
  *  End of namespace
  */
 }
+/*
+ * NOTE
+ * Regarding the limitations of this handler.
+ *
+ * This handler is inspired by the others that preceded it (i.e. LibEvHandler,
+ * LibEventHandler, LibUvHandler), but the strategy used to monitor the socket
+ * filedescriptor is completely different.  While other handlers rely on calls
+ * like select/poll or similar to be woken up when a filedescriptor becomes
+ * readable/writable, this one uses boost's async_wait.
+ * Since callbacks queued in the execution context are not automatically
+ * requeued once executed, additional work is required to continue monitoring
+ * the socket's readability/writableness.  This is not necessary with the other
+ * approaches, furthermore with select/poll/etc it is the operating system that
+ * checks multiple conditions *simultaneously*, whereas here we are also forced
+ * to manage readable and writeable conditions separately.
+ *
+ * This brings us to the need to use a state machine, which is implemented here
+ * using the boolean flags _read, _read_pending, _write, _write_pending.
+ * As you can see the _pending flags are used to reschedule callbacks, so if
+ * for some reason the thread is suspended after setting the flag but before
+ * rescheduling the callback this can result in missed reads/writes.
+ *
+ * Even though all library callbacks are executed in order on the same strand,
+ * this is YET ANOTHER reason to stick to a single-threaded execution model.
+ *
+ * Anyway I have already fixed this race condition in a future version of the
+ * handler that will do without such flags.
+ *                                                             Paolo
+ */

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -1,11 +1,11 @@
 /**
  *  LibBoostAsio.h
  *
- *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class 
- *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the 
+ *  Implementation for the AMQP::TcpHandler for boost::asio. You can use this class
+ *  instead of a AMQP::TcpHandler class, just pass the boost asio service to the
  *  constructor and you're all set.  See tests/libboostasio.cpp for example.
  *
- *  Watch out: this class was not implemented or reviewed by the original author of 
+ *  Watch out: this class was not implemented or reviewed by the original author of
  *  AMQP-CPP. However, we do get a lot of questions and issues from users of this class,
  *  so we cannot guarantee its quality. If you run into such issues too, it might be
  *  better to implement your own handler that interact with boost.
@@ -13,7 +13,6 @@
  *
  *  @author Gavin Smith <gavin.smith@coralbay.tv>
  */
-
 
 /**
  *  Include guard
@@ -26,7 +25,7 @@
 #include <memory>
 
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/strand.hpp>
+#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
@@ -72,7 +71,7 @@ protected:
 
         /**
          *  The boost asio io_context::strand managed pointer.
-         *  @var class std::shared_ptr<boost::asio::io_context>
+         *  @var std::weak_ptr<boost::asio::io_context::strand>
          */
         strand_weak_ptr _wpstrand;
 
@@ -93,25 +92,25 @@ protected:
          *  A boolean that indicates if the watcher is monitoring for read events.
          *  @var _read True if reads are being monitored else false.
          */
-        bool _read{false};
+        bool _read = false;
 
         /**
          *  A boolean that indicates if the watcher has a pending read event.
-         *  @var _read True if read is pending else false.
+         *  @var _read_pending True if read is pending else false.
          */
-        bool _read_pending{false};
+        bool _read_pending = false;
 
         /**
          *  A boolean that indicates if the watcher is monitoring for write events.
-         *  @var _read True if writes are being monitored else false.
+         *  @var _write True if writes are being monitored else false.
          */
-        bool _write{false};
+        bool _write = false;
 
         /**
          *  A boolean that indicates if the watcher has a pending write event.
-         *  @var _read True if read is pending else false.
+         *  @var _write_pending True if read is pending else false.
          */
-        bool _write_pending{false};
+        bool _write_pending = false;
 
         using handler_cb = boost::function<void(boost::system::error_code,std::size_t)>;
         using io_handler = boost::function<void(const boost::system::error_code&, const std::size_t)>;
@@ -305,6 +304,7 @@ protected:
         }
 
     public:
+
         /**
          *  Constructor- initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
@@ -414,13 +414,13 @@ protected:
 
     /**
      *  The boost asio io_context::strand managed pointer.
-     *  @var class std::shared_ptr<boost::asio::io_context>
+     *  @var std::shared_ptr<boost::asio::io_context::strand>
      */
     strand_shared_ptr _strand;
 
     /**
-     *  All I/O watchers that are active, indexed by their filedescriptor
-     *  @var std::map<int,Watcher>
+     *  Active I/O watchers, indexed by their filedescriptor.
+     *  @var std::map<int, Watcher>
      */
     std::map<int, std::shared_ptr<Watcher> > _watchers;
 
@@ -460,11 +460,12 @@ protected:
         else
         {
             // Change the events on which to act.
-            iter->second->events(connection,fd,flags);
+            iter->second->events(connection, fd, flags);
         }
     }
 
 protected:
+
     /**
      *  Method that is called when the heartbeat frequency is negotiated between the server and the client.
      *  @param  connection      The connection that suggested a heartbeat interval
@@ -492,8 +493,6 @@ public:
 
     /**
      *  Handler cannot be default constructed.
-     *
-     *  @param  that    The object to not move or copy
      */
     LibBoostAsioHandler() = delete;
 
@@ -531,7 +530,6 @@ public:
      */
     ~LibBoostAsioHandler() override = default;
 };
-
 
 /**
  *  End of namespace

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -78,16 +78,40 @@ protected:
 
         /**
          *  The boost asynchronous timer.
+         *
+         *  Used for monitoring of both server connection timeout condition
+         *  (at initial connection stage) and heartbeat (client and server).
          *  @var boost::asio::steady_timer
          */
         boost::asio::steady_timer _timer;
 
         /**
+         *  AMQP Server connection timeout setting (seconds).
+         *  @var uint16_t
+         */
+        uint16_t _connection_timeout = 0;
+
+        /**
          *  Timeout after which the connection is no longer considered alive.
+         *  A heartbeat must be sent every _timeout / 2 seconds.
          *  Value zero means heartbeats are disabled, or not yet negotiated.
          *  @var uint16_t
          */
         uint16_t _timeout = 0;
+
+        using steady_time_point = std::chrono::time_point<std::chrono::steady_clock>;
+
+        /**
+         *  When should we send the next heartbeat?
+         *  @var std::chrono::time_point<std::chrono::steady_clock>
+         */
+        steady_time_point _next;
+
+        /**
+         *  When does the connection expire / was the server idle for too long?
+         *  @var std::chrono::time_point<std::chrono::steady_clock>
+         */
+        steady_time_point _expire;
 
         /**
          *  A boolean that indicates if the watcher is monitoring for read events.
@@ -172,6 +196,13 @@ protected:
 
             if (!ec && _read)
             {
+                if (_timeout)
+                {
+                    // the server is sending data, update the _expire time
+                    _expire = std::chrono::steady_clock::now() +
+                            std::chrono::seconds(_timeout + (_timeout >> 1) + 1);
+                }
+
                 connection->process(fd, AMQP::readable);
 
                 // still we need monitoring read?
@@ -242,11 +273,41 @@ protected:
         {
             if (!ec && _socket.is_open())
             {
-                // send the heartbeat
-                connection->heartbeat();
+                steady_time_point now = std::chrono::steady_clock::now();
+
+                if (_timeout == 0)
+                {
+                    // this can happen in three situations:
+                    // 1. a connection timeout,
+                    // 2. user space has overidden onNegotiate to reject heartbeats
+                    // 3. AMQP server does not want heartbeats
+                    // in either case we're no longer going to run further timers.
+
+                    // if we have an initialized connection, user space must have overidden
+                    // the onNegotiate method, so we keep using the connection
+                    if (connection->initialized()) return;
+
+                    // this is a connection timeout, close the connection with immediate effect
+                    return (void) connection->close(true);
+                }
+                else if (now >= _expire)
+                {
+                    // the server was inactive for a too long period of time,
+                    // close the connection with immediate effect
+                    _timeout = 0;
+                    return (void) connection->close(true);
+                }
+                else if (now >= _next)
+                {
+                    // send the heartbeat
+                    connection->heartbeat();
+
+                    // when we should send out the next one
+                    _next = now + std::chrono::seconds((_timeout >> 1) + 1);
+                }
 
                 // reschedule the timer
-                _timer.expires_after(std::chrono::seconds(_timeout));
+                _timer.expires_at(_next);
 
                 // Posts the timer event
                 _timer.async_wait(get_timer_handler(connection, fd));
@@ -265,17 +326,20 @@ protected:
         /**
          *  Constructor - initialises the watcher and assigns the filedescriptor to
          *  a boost socket for monitoring.
-         *  @param  io_context      The boost io_context
-         *  @param  wpstrand        A weak pointer to a io_context::strand instance.
-         *  @param  fd              The filedescriptor being watched
+         *  @param  io_context           The boost io_context
+         *  @param  wpstrand             A weak pointer to a io_context::strand instance.
+         *  @param  fd                   The filedescriptor being watched
+         *  @param  connection_timeout   The AMQP server connection timeout
          */
         Watcher(boost::asio::io_context &io_context,
                 const strand_weak_ptr wpstrand,
-                const int fd) :
+                const int fd,
+                uint16_t connection_timeout) :
             _iocontext(io_context),
             _wpstrand(wpstrand),
             _socket(io_context),
-            _timer(io_context)
+            _timer(io_context),
+            _connection_timeout(connection_timeout)
         {
             _socket.assign(fd);
 
@@ -337,6 +401,23 @@ protected:
         }
 
         /**
+         *  Apply AMQP server connection timeout watching.
+         *  @param  connection  The connection being watched.
+         *  @param  fd          The file descripter being watched.
+         */
+        void apply_connection_timeout(TcpConnection *const connection, const int fd)
+        {
+            if (_connection_timeout && !_timeout)
+            {
+                // schedule the timer
+                _timer.expires_after(std::chrono::seconds(_connection_timeout));
+
+                // Posts the timer event
+                _timer.async_wait(get_timer_handler(connection, fd));
+            }
+        }
+
+        /**
          *  Configure the heartbeat interval to use
          *  @param timeout      The timeout value (seconds, 0 to disable heartbeat monitor.)
          */
@@ -357,8 +438,13 @@ protected:
 
             if (_timeout)
             {
+                // when we should send out the next heartbeat
+                _next = std::chrono::steady_clock::now() + std::chrono::seconds((_timeout >> 1) + 1);
+                // by when we should expect some server activity
+                _expire = _next + std::chrono::seconds(_timeout);
+
                 // schedule the timer
-                _timer.expires_after(std::chrono::seconds(_timeout));
+                _timer.expires_at(_next);
 
                 // Posts the timer event
                 _timer.async_wait(get_timer_handler(connection, fd));
@@ -396,6 +482,12 @@ protected:
     std::map<int, std::shared_ptr<Watcher> > _watchers;
 
     /**
+     *  AMQP Server connection timeout setting (seconds).
+     *  @var uint16_t
+     */
+    uint16_t _connection_timeout;
+
+    /**
      *  Method that is called by AMQP-CPP to register a filedescriptor for readability or writability
      *  @param  connection  The TCP connection object that is reporting
      *  @param  fd          The filedescriptor to be monitored
@@ -416,10 +508,13 @@ protected:
 
             // construct a new watcher
             const std::shared_ptr<Watcher> spwatcher =
-                std::make_shared<Watcher>(_iocontext, _strand, fd);
+                std::make_shared<Watcher>(_iocontext, _strand, fd, _connection_timeout);
 
             // register as active
             _watchers[fd] = spwatcher;
+
+            // apply server connection timeout monitor
+            spwatcher->apply_connection_timeout(connection, fd);
 
             // explicitly set the events to monitor
             spwatcher->events(connection, fd, flags);
@@ -475,11 +570,14 @@ public:
 
     /**
      *  Constructor
-     *  @param  io_context    The boost io_context to wrap
+     *  @param  io_context          The boost io_context to wrap
+     *  @param  connection_timeout  The AMQP server connection timeout (seconds)
      */
-    explicit LibBoostAsioHandler(boost::asio::io_context &io_context) :
+    explicit LibBoostAsioHandler(boost::asio::io_context &io_context,
+                                 uint16_t connection_timeout = 60) :
         _iocontext(io_context),
-        _strand(std::make_shared<boost::asio::io_context::strand>(_iocontext))
+        _strand(std::make_shared<boost::asio::io_context::strand>(_iocontext)),
+        _connection_timeout(connection_timeout)
     {
     }
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -203,7 +203,7 @@ protected:
                 // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring read?
-                if (_read && _socket.is_open())
+                if (_socket.is_open())
                 {
                     _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_read,
@@ -240,7 +240,7 @@ protected:
                 // Beware, the library may have triggered the watcher destruction
 
                 // still we need monitoring write?
-                if (_write && _socket.is_open())
+                if (_socket.is_open())
                 {
                     _socket.async_wait(
                         boost::asio::posix::stream_descriptor::wait_write,
@@ -470,7 +470,7 @@ protected:
 
     /**
      *  Active I/O watchers, indexed by their filedescriptor.
-     *  @var std::map<int, std::unique_ptr<Watcher>>
+     *  @var std::map<int, Watcher>
      */
     std::map<int, std::unique_ptr<Watcher>> _watchers;
 

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -240,13 +240,10 @@ protected:
                            TcpConnection *const connection,
                            const int fd)
         {
-            if (!ec)
+            if (!ec && _socket.is_open())
             {
-                if (connection)
-                {
-                    // send the heartbeat
-                    connection->heartbeat();
-                }
+                // send the heartbeat
+                connection->heartbeat();
 
                 // reschedule the timer
                 _timer.expires_after(std::chrono::seconds(_timeout));

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -115,7 +115,6 @@ protected:
 
         using handler_cb = boost::function<void(boost::system::error_code)>;
         using io_handler = boost::function<void(const boost::system::error_code&)>;
-        using timer_cb = boost::function<void(boost::system::error_code)>;
 
         /**
          * Builds a io handler callback that executes the io callback in a strand.
@@ -129,12 +128,10 @@ protected:
             return [fn, wpstrand](const boost::system::error_code &ec)
             {
                 const strand_shared_ptr strand = wpstrand.lock();
-                if (!strand)
-                {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
-                    return;
-                }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
+                // is the strand still here?
+                if (!strand) return;
+
+                boost::asio::dispatch(*strand, boost::bind(fn, ec));
             };
         }
 
@@ -178,7 +175,7 @@ protected:
          * @param  timeout      The file descripter being watched.
          * @return handler callback
          */
-        timer_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
+        handler_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
         {
             const auto fn = boost::bind(&Watcher::timeout_handler,
                                   this,
@@ -186,19 +183,7 @@ protected:
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   timeout);
-
-            const strand_weak_ptr wpstrand = _wpstrand;
-
-            return [fn, wpstrand](const boost::system::error_code &ec)
-            {
-                const strand_shared_ptr strand = wpstrand.lock();
-                if (!strand)
-                {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
-                    return;
-                }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
-            };
+            return get_dispatch_wrapper(fn);
         }
 
         /**

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -24,23 +24,15 @@
  */
 #include <memory>
 #include <chrono>
+#include <functional>
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/dispatch.hpp>
-#include <boost/bind/bind.hpp>
-#include <boost/function.hpp>
 
 #include "amqpcpp/linux_tcp.h"
-
-// C++17 has 'weak_from_this()' support.
-#if __cplusplus >= 201701L
-#define PTR_FROM_THIS(T) weak_from_this()
-#else
-#define PTR_FROM_THIS(T) std::weak_ptr<T>(shared_from_this())
-#endif
 
 /**
  *  Set up namespace
@@ -90,6 +82,13 @@ protected:
         boost::asio::steady_timer _timer;
 
         /**
+         *  Timeout after which the connection is no longer considered alive.
+         *  Value zero means heartbeats are disabled, or not yet negotiated.
+         *  @var uint16_t
+         */
+        uint16_t _timeout = 0;
+
+        /**
          *  A boolean that indicates if the watcher is monitoring for read events.
          *  @var _read True if reads are being monitored else false.
          */
@@ -113,97 +112,61 @@ protected:
          */
         bool _write_pending = false;
 
-        using handler_cb = boost::function<void(boost::system::error_code)>;
-        using io_handler = boost::function<void(const boost::system::error_code&)>;
+        using handler_cb = std::function<void(boost::system::error_code)>;
 
         /**
-         * Builds a io handler callback that executes the io callback in a strand.
-         * @param  io_handler  The handler callback to dispatch
-         * @return handler_cb  A function wrapping the execution of the handler function in a io_context::strand.
+         *  Make a generic handler callback.
+         *  @param  mmfn        The wrapping member pointer to be invoked by the handler.
+         *  @param  connection  The connection being watched.
+         *  @param  fd          The file descriptor being watched.
+         *  @return handler_cb
          */
-        handler_cb get_dispatch_wrapper(io_handler fn)
+        template <typename M>
+        handler_cb make_handler(M &&mmfn, TcpConnection *const connection, const int fd)
         {
+#if __cplusplus >= 201701L
+            // C++17 has weak_from_this()
+            std::weak_ptr<Watcher> wpthis = weak_from_this();
+#else
+            std::weak_ptr<Watcher> wpthis(shared_from_this());
+#endif
             const strand_weak_ptr wpstrand = _wpstrand;
 
-            return [fn, wpstrand](const boost::system::error_code &ec)
-            {
-                const strand_shared_ptr strand = wpstrand.lock();
-                // is the strand still here?
-                if (!strand) return;
+            return
+#if __cplusplus >= 201402L
+                // C++14 lambda has init capture
+                [wpthis=std::move(wpthis), wpstrand=std::move(wpstrand), mmfn=std::forward<M>(mmfn),
+                                         connection, fd] (const boost::system::error_code& ec)
+#else
+                [wpthis, wpstrand, mmfn, connection, fd] (const boost::system::error_code& ec)
+#endif
+                {
+                    const std::shared_ptr<Watcher> spwatcher = wpthis.lock();
+                    // is the watcher still here?
+                    if (!spwatcher) return;
 
-                boost::asio::dispatch(*strand, boost::bind(fn, ec));
-            };
-        }
+                    const strand_shared_ptr strand = wpstrand.lock();
+                    // is the strand still here?
+                    if (!strand) return;
 
-        /**
-         * Binds and returns a read handler for the io operation.
-         * @param  connection   The connection being watched.
-         * @param  fd           The file descripter being watched.
-         * @return handler callback
-         */
-        handler_cb get_read_handler(TcpConnection *const connection, const int fd)
-        {
-            auto fn = boost::bind(&Watcher::read_handler,
-                                  this,
-                                  boost::placeholders::_1,
-                                  PTR_FROM_THIS(Watcher),
-                                  connection,
-                                  fd);
-            return get_dispatch_wrapper(fn);
-        }
-
-        /**
-         * Binds and returns a read handler for the io operation.
-         * @param  connection   The connection being watched.
-         * @param  fd           The file descripter being watched.
-         * @return handler callback
-         */
-        handler_cb get_write_handler(TcpConnection *const connection, const int fd)
-        {
-            auto fn = boost::bind(&Watcher::write_handler,
-                                  this,
-                                  boost::placeholders::_1,
-                                  PTR_FROM_THIS(Watcher),
-                                  connection,
-                                  fd);
-            return get_dispatch_wrapper(fn);
-        }
-
-        /**
-         * Binds and returns a lamba function handler for the io operation.
-         * @param  connection   The connection being watched.
-         * @param  timeout      The file descripter being watched.
-         * @return handler callback
-         */
-        handler_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
-        {
-            const auto fn = boost::bind(&Watcher::timeout_handler,
-                                  this,
-                                  boost::placeholders::_1,
-                                  PTR_FROM_THIS(Watcher),
-                                  connection,
-                                  timeout);
-            return get_dispatch_wrapper(fn);
+                    boost::asio::dispatch(*strand,
+                        // moving spwatcher into the bind ensures that the watcher
+                        // will not be destroyed for the duration of the callback
+                        std::bind(std::move(mmfn), std::move(spwatcher), ec, connection, fd));
+                };
         }
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a read event.
          *  @param  ec          The status of the callback.
-         *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a read is cancelled.
          */
         void read_handler(const boost::system::error_code &ec,
-                          const std::weak_ptr<Watcher> awpWatcher,
                           TcpConnection *const connection,
                           const int fd)
         {
-            // Resolve any potential problems with dangling pointers
-            // (remember we are using async).
-            const std::shared_ptr<Watcher> apWatcher = awpWatcher.lock();
-            if (!apWatcher) { return; }
-
             _read_pending = false;
 
             if (!ec && _read)
@@ -221,25 +184,25 @@ protected:
                 }
             }
         }
+        /**
+         *  Make a handler callback to invoke the read_handler method.
+         */
+        handler_cb get_read_handler(TcpConnection *const connection, const int fd)
+        {
+            return make_handler(std::mem_fn(&Watcher::read_handler), connection, fd);
+        }
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a write event.
          *  @param  ec          The status of the callback.
-         *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a write is cancelled.
          */
         void write_handler(const boost::system::error_code ec,
-                           const std::weak_ptr<Watcher> awpWatcher,
                            TcpConnection *const connection,
                            const int fd)
         {
-            // Resolve any potential problems with dangling pointers
-            // (remember we are using async).
-            const std::shared_ptr<Watcher> apWatcher = awpWatcher.lock();
-            if (!apWatcher) { return; }
-
             _write_pending = false;
 
             if (!ec && _write)
@@ -257,25 +220,25 @@ protected:
                 }
             }
         }
+        /**
+         *  Make a handler callback to invoke the write_handler method.
+         */
+        handler_cb get_write_handler(TcpConnection *const connection, const int fd)
+        {
+            return make_handler(std::mem_fn(&Watcher::write_handler), connection, fd);
+        }
 
         /**
-         *  Callback method that is called by libev when the timer expires
-         *  @param  ec          error code returned from loop
-         *  @param  loop        The loop in which the event was triggered
-         *  @param  connection
-         *  @param  timeout
+         *  Handler method that is called by boost's io_context when the timer expires.
+         *  @param  ec          The status of the callback.
+         *  @param  connection  The connection being watched.
+         *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a timer is cancelled.
          */
-        void timeout_handler(const boost::system::error_code &ec,
-                     std::weak_ptr<Watcher> awpThis,
-                     TcpConnection *const connection,
-                     const uint16_t timeout)
+        void timer_handler(const boost::system::error_code &ec,
+                           TcpConnection *const connection,
+                           const int fd)
         {
-            // Resolve any potential problems with dangling pointers
-            // (remember we are using async).
-            const std::shared_ptr<Watcher> apTimer = awpThis.lock();
-            if (!apTimer) { return; }
-
             if (!ec)
             {
                 if (connection)
@@ -285,11 +248,18 @@ protected:
                 }
 
                 // reschedule the timer
-                _timer.expires_after(std::chrono::seconds(timeout));
+                _timer.expires_after(std::chrono::seconds(_timeout));
 
                 // Posts the timer event
-                _timer.async_wait(get_timer_handler(connection, timeout));
+                _timer.async_wait(get_timer_handler(connection, fd));
             }
+        }
+        /**
+         *  Make a handler callback to invoke the timer_handler method.
+         */
+        handler_cb get_timer_handler(TcpConnection *const connection, const int fd)
+        {
+            return make_handler(std::mem_fn(&Watcher::timer_handler), connection, fd);
         }
 
     public:
@@ -369,22 +339,31 @@ protected:
         }
 
         /**
-         *  Change the expire time
-         *  @param  connection
-         *  @param  timeout
+         *  Configure the heartbeat interval to use
+         *  @param timeout      The timeout value (seconds, 0 to disable heartbeat monitor.)
          */
-        void set_timer(TcpConnection *connection, uint16_t timeout)
+        void set_heartbeat(uint16_t timeout)
+        {
+            _timeout = timeout;
+        }
+
+        /**
+         *  Schedule the timer
+         *  @param  connection  The connection being watched.
+         *  @param  fd          The file descripter being watched.
+         */
+        void set_timer(TcpConnection *const connection, const int fd)
         {
             // stop timer in case it was already set
             stop_timer();
 
-            if (timeout)
+            if (_timeout)
             {
                 // schedule the timer
-                _timer.expires_after(std::chrono::seconds(timeout));
+                _timer.expires_after(std::chrono::seconds(_timeout));
 
                 // Posts the timer event
-                _timer.async_wait(get_timer_handler(connection, timeout));
+                _timer.async_wait(get_timer_handler(connection, fd));
             }
         }
 
@@ -461,26 +440,27 @@ protected:
 protected:
 
     /**
-     *  Method that is called when the heartbeat frequency is negotiated between the server and the client.
-     *  @param  connection      The connection that suggested a heartbeat interval
-     *  @param  interval        The suggested interval from the server
-     *  @return uint16_t        The interval to use
+     *  Method that is called when the heartbeat frequency is negotiated.
+     *  @param  connection      The connection that suggested a heartbeat timeout
+     *  @param  timeout         The suggested timeout from the server (seconds)
+     *  @return uint16_t        The timeout to use
      */
-    virtual uint16_t onNegotiate(TcpConnection *connection, uint16_t interval) override
+    uint16_t onNegotiate(TcpConnection *connection, uint16_t timeout) override
     {
         // skip if no heartbeats are needed
-        if (interval == 0) return 0;
+        if (timeout == 0) return 0;
 
-        const auto fd = connection->fileno();
+        const int fd = connection->fileno();
 
         auto iter = _watchers.find(fd);
         if (iter == _watchers.end()) return 0;
 
-        // set the timer
-        iter->second->set_timer(connection, interval);
+        // apply heartbeat monitor
+        iter->second->set_heartbeat(timeout);
+        iter->second->set_timer(connection, fd);
 
-        // we agree with the interval
-        return interval;
+        // we agree with the timeout
+        return timeout;
     }
 
 public:

--- a/include/amqpcpp/libboostasio.h
+++ b/include/amqpcpp/libboostasio.h
@@ -113,9 +113,9 @@ protected:
          */
         bool _write_pending = false;
 
-        using handler_cb = boost::function<void(boost::system::error_code,std::size_t)>;
-        using io_handler = boost::function<void(const boost::system::error_code&, const std::size_t)>;
-        using timer_handler = boost::function<void(boost::system::error_code)>;
+        using handler_cb = boost::function<void(boost::system::error_code)>;
+        using io_handler = boost::function<void(const boost::system::error_code&)>;
+        using timer_cb = boost::function<void(boost::system::error_code)>;
 
         /**
          * Builds a io handler callback that executes the io callback in a strand.
@@ -126,15 +126,15 @@ protected:
         {
             const strand_weak_ptr wpstrand = _wpstrand;
 
-            return [fn, wpstrand](const boost::system::error_code &ec, const std::size_t bytes_transferred)
+            return [fn, wpstrand](const boost::system::error_code &ec)
             {
                 const strand_shared_ptr strand = wpstrand.lock();
                 if (!strand)
                 {
-                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled), std::size_t{0});
+                    fn(boost::system::errc::make_error_code(boost::system::errc::operation_canceled));
                     return;
                 }
-                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec, bytes_transferred));
+                boost::asio::dispatch(strand->context().get_executor(), boost::bind(fn, ec));
             };
         }
 
@@ -149,7 +149,6 @@ protected:
             auto fn = boost::bind(&Watcher::read_handler,
                                   this,
                                   boost::placeholders::_1,
-                                  boost::placeholders::_2,
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
@@ -167,7 +166,6 @@ protected:
             auto fn = boost::bind(&Watcher::write_handler,
                                   this,
                                   boost::placeholders::_1,
-                                  boost::placeholders::_2,
                                   PTR_FROM_THIS(Watcher),
                                   connection,
                                   fd);
@@ -180,7 +178,7 @@ protected:
          * @param  timeout      The file descripter being watched.
          * @return handler callback
          */
-        timer_handler get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
+        timer_cb get_timer_handler(TcpConnection *const connection, const uint16_t timeout)
         {
             const auto fn = boost::bind(&Watcher::timeout_handler,
                                   this,
@@ -206,14 +204,12 @@ protected:
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a read event.
          *  @param  ec          The status of the callback.
-         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a read is cancelled.
          */
         void read_handler(const boost::system::error_code &ec,
-                          const std::size_t bytes_transferred,
                           const std::weak_ptr<Watcher> awpWatcher,
                           TcpConnection *const connection,
                           const int fd)
@@ -225,29 +221,31 @@ protected:
 
             _read_pending = false;
 
-            if ((!ec || ec == boost::asio::error::would_block) && _read)
+            if (!ec && _read)
             {
                 connection->process(fd, AMQP::readable);
 
-                _read_pending = true;
+                // still we need monitoring read?
+                if (_socket.is_open())
+                {
+                    _read_pending = true;
 
-                _socket.async_read_some(
-                    boost::asio::null_buffers(),
-                    get_read_handler(connection, fd));
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_read,
+                        get_read_handler(connection, fd));
+                }
             }
         }
 
         /**
          *  Handler method that is called by boost's io_context when the socket pumps a write event.
          *  @param  ec          The status of the callback.
-         *  @param  bytes_transferred The number of bytes transferred.
          *  @param  awpWatcher  A weak pointer to this object.
          *  @param  connection  The connection being watched.
          *  @param  fd          The file descriptor being watched.
          *  @note   The handler will get called if a write is cancelled.
          */
         void write_handler(const boost::system::error_code ec,
-                           const std::size_t bytes_transferred,
                            const std::weak_ptr<Watcher> awpWatcher,
                            TcpConnection *const connection,
                            const int fd)
@@ -259,15 +257,19 @@ protected:
 
             _write_pending = false;
 
-            if ((!ec || ec == boost::asio::error::would_block) && _write)
+            if (!ec && _write)
             {
                 connection->process(fd, AMQP::writable);
 
-                _write_pending = true;
+                // still we need monitoring write?
+                if (_socket.is_open())
+                {
+                    _write_pending = true;
 
-                _socket.async_write_some(
-                    boost::asio::null_buffers(),
-                    get_write_handler(connection, fd));
+                    _socket.async_wait(
+                        boost::asio::posix::stream_descriptor::wait_write,
+                        get_write_handler(connection, fd));
+                }
             }
         }
 
@@ -277,6 +279,7 @@ protected:
          *  @param  loop        The loop in which the event was triggered
          *  @param  connection
          *  @param  timeout
+         *  @note   The handler will get called if a timer is cancelled.
          */
         void timeout_handler(const boost::system::error_code &ec,
                      std::weak_ptr<Watcher> awpThis,
@@ -359,8 +362,8 @@ protected:
             {
                 _read_pending = true;
 
-                _socket.async_read_some(
-                    boost::asio::null_buffers(),
+                _socket.async_wait(
+                    boost::asio::posix::stream_descriptor::wait_read,
                     get_read_handler(connection, fd));
             }
 
@@ -372,8 +375,8 @@ protected:
             {
                 _write_pending = true;
 
-                _socket.async_write_some(
-                    boost::asio::null_buffers(),
+                _socket.async_wait(
+                    boost::asio::posix::stream_descriptor::wait_write,
                     get_write_handler(connection, fd));
             }
         }

--- a/src/linux_tcp/tcpconnection.cpp
+++ b/src/linux_tcp/tcpconnection.cpp
@@ -27,7 +27,7 @@ namespace AMQP {
 TcpConnection::TcpConnection(TcpHandler *handler, const Address &address) :
     _handler(handler),
     _state(new TcpResolver(this, address.hostname(), address.port(), address.secure(), address.option("connectTimeout", 5), ConnectionOrder(address.option("connectionOrder")))),
-    _connection(this, address.login(), address.vhost()) 
+    _connection(this, address.login(), address.vhost())
 {
     // tell the handler
     _handler->onAttached(this);
@@ -97,8 +97,8 @@ void TcpConnection::process(int fd, int flags)
 
     // remember the old state
     auto *oldstate = _state.get();
-        
-    // pass on the the state, that returns a new impl
+
+    // pass on the state, that returns a new impl
     auto *newstate = _state->process(monitor, fd, flags);
 
     // if the state did not change, we do not have to update a member,
@@ -109,7 +109,7 @@ void TcpConnection::process(int fd, int flags)
     // wrap the new state in a unique-ptr so that so that the old state
     // is not destructed before the new one is assigned
     std::unique_ptr<TcpState> ptr(newstate);
-    
+
     // swap the two pointers (this ensures that the last operation of this
     // method is to destruct the old state, which possible results in calls
     // to user-space and the destruction of "this"
@@ -118,7 +118,7 @@ void TcpConnection::process(int fd, int flags)
 }
 
 /**
- *  Close the connection. 
+ *  Close the connection.
  *  Warning: this potentially directly calls several handlers (onError, onLost, onDetached)
  *  @return bool
  */
@@ -129,10 +129,10 @@ bool TcpConnection::close(bool immediate)
 
     // failing the connection could destruct "this"
     Monitor monitor(this);
-    
+
     // fail the connection / report the error to user-space
     bool failed = _connection.fail("connection prematurely closed by client");
-    
+
     // stop if object was destructed
     if (!monitor.valid()) return true;
 
@@ -142,7 +142,7 @@ bool TcpConnection::close(bool immediate)
     // stop if object was destructed
     if (!monitor.valid()) return true;
 
-    // also call the lost handler, we have now lost the connection from this state (since we force-closed). 
+    // also call the lost handler, we have now lost the connection from this state (since we force-closed).
     // this makes sure the onLost and onDetached is properly called.
     onLost(_state.get());
 
@@ -157,7 +157,7 @@ bool TcpConnection::close(bool immediate)
 }
 
 /**
- *  Method that is called when the RabbitMQ server and your client application  
+ *  Method that is called when the RabbitMQ server and your client application
  *  exchange some properties that describe their identity.
  *  @param  connection      The connection about which information is exchanged
  *  @param  server          Properties sent by the server
@@ -179,7 +179,7 @@ uint16_t TcpConnection::onNegotiate(Connection *connection, uint16_t interval)
 {
     // tell the max-frame size
     _state->maxframe(connection->maxFrame());
-    
+
     // tell the handler
     return _handler ? _handler->onNegotiate(this, interval) : interval;
 }
@@ -205,13 +205,13 @@ void TcpConnection::onError(Connection *connection, const char *message)
 {
     // monitor to check if "this" is destructed
     Monitor monitor(this);
-    
+
     // tell this to the user
     if (_handler) _handler->onError(this, message);
-    
+
     // object could be destructed by user-space
     if (!monitor.valid()) return;
-    
+
     // tell the state that the connection should be closed asap
     _state->close();
 }
@@ -224,7 +224,7 @@ void TcpConnection::onClosed(Connection *connection)
 {
     // tell the state that the connection should be closed asap
     _state->close();
-    
+
     // report to the handler
     _handler->onClosed(this);
 }
@@ -242,10 +242,10 @@ void TcpConnection::onError(TcpState *state, const char *message, bool connected
 
     // monitor to check if all operations are active
     Monitor monitor(this);
-    
+
     // if there are still pending operations, they should be reported as error
     bool failed = _connection.fail(message);
-    
+
     // stop if object was destructed
     if (!monitor.valid()) return;
 
@@ -255,7 +255,7 @@ void TcpConnection::onError(TcpState *state, const char *message, bool connected
     // if the object is still connected, we only have to report the error and
     // we wait for the subsequent call to the onLost() method
     if (connected || !monitor.valid()) return;
-    
+
     // tell the handler that no further events will be fired
     _handler->onDetached(this);
 }
@@ -268,16 +268,16 @@ void TcpConnection::onLost(TcpState *state)
 {
     // if user-space is no longer interested in this object, the rest of the code is pointless here
     if (_handler == nullptr) return;
-    
+
     // monitor to check if "this" is destructed
     Monitor monitor(this);
-    
+
     // tell the handler
     _handler->onLost(this);
-    
+
     // leap out if object was destructed
     if (!monitor.valid()) return;
-    
+
     // tell the handler that no further events will be fired
     _handler->onDetached(this);
 }


### PR DESCRIPTION
> [!NOTE]
> This is the sixth and **last** child, the code is branched from #562 (fifth child), so this one accumulate the changes.

Each commit has been checked for regressions.

+ 1870a70a8c9b84af1276a1aef72e96efbec6d375 finally, complete liberation from the useless shared_ptr is achieved, 23 commits ago, I never thought I'd see this... Now not only does the `Watcher` no longer have to inherit from `enable_shared_from_this`, but more importantly, the `make_handler` avoids creating another pair of weak/shared ptr to guard `this` (which previously was done at every callback invocation, i.e. every time the socket becomes readable or writable, even just to receive 1 byte!) But `make_handler` is now smarter for another reason too: in case of errors from boost it exits immediately without calling the callback at all. As I already explained, this, together with the cancellation of the callbacks by the destructor, allows you not to have to worry too much about the dangling of the `this`. Finally, the handler now stores children using `unique_ptrs` instead of `shared_ptrs`. Simple pointers could have been used, but I preferred to stay aligned with the other handlers. Now, when you erase the child in the map, the object is certainly destroyed. There are no delays of any kind, and no need to be careful to avoid releasing sockets too late. In short, everything works as expected, with no surprises. This is the greatest benefit for anyone who reads or maintains the code. This and a certain amount of appropriate comments added where needed.
+ 1c11cd9f4d9b2a23f7b22f2785da593c7a659ed3 given that callback methods are never called when boost reports an error, it is clear that they do not need to have the error as a parameter.
+ b1355f1c5b47136385884ef8a75a238c203363d1 I replaced the pointer to the parent in the watchers with a reference to the `strand`, after all they don't ask much else from their parent.

As usual, for the more impatient among you, I'm leaving this latest version below. If the one that existed before I started working on it _was in production_, well, then this one _can go to Mars_.

> [!IMPORTANT]
> [**libboostasio_2025-12-23.zip**](https://github.com/user-attachments/files/24314828/libboostasio_2025-12-23.zip)